### PR TITLE
Team auctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Version
 
 ### Added
 
+![Team Auctions](https://i.ibb.co/vCYzR3R6/image.png)
+
 - **Team Auctions**: team-scoped listings visible and purchasable only by members of the seller's team.
   - New command: `/auction team` — browse team listings (hidden when disabled or TeamsAPI absent).
   - New command: `/auction team sell` — list held item as a team auction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to EzAuction are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Release tags use the `v` prefix (e.g. `v2.2.0`).
+
+## [Unreleased]
+
+---
+
+## [2.2.0] - 2026-05-11
+
+### Added
+
+- **Team Auctions**: team-scoped listings visible and purchasable only by members of the seller's team.
+  - New command: `/auction team` — browse team listings (hidden when disabled or TeamsAPI absent).
+  - New command: `/auction team sell` — list held item as a team auction.
+  - `team-auctions.enabled` toggle in `auction.yml` (default `false`).
+  - `TeamsIntegration` facade — null-safe soft-dependency wrapper around [TeamsAPI 1.4.0](https://github.com/ez-plugins/teams-api).
+  - `AuctionListing.teamId` field persisted to both YAML and MySQL backends.
+  - `AuctionListingService` team scope and `AuctionQueryService` team query, both guarded by the config flag.
+  - `AuctionManager.createTeamListing()` and `listActiveTeamListings()`.
+  - Team browse tab in the auction browser GUI; tab button hidden when team auctions are disabled or TeamsAPI is not installed.
+  - `TeamsAPI` added to `softdepend` in `plugin.yml`.
+  - Full message keys added across all four language files (`en`, `es`, `nl`, `zh`).
+  - New permissions: `ezauction.auction.team`, `ezauction.auction.team.sell`.
+
+### Added (sell menu)
+
+- Price-adjustment buttons replaced with coloured glass panes (lime = increase, red = decrease).
+- Second row of quantity-adjustment buttons (same glass style) to select how many of a stack to list.
+- `SellMenuState.quantity()` — tracks the chosen listing amount, clamped to `[1, item stack size]`.
+- `SellMenuInteractionConfiguration.quantityAdjustments` — configurable quantity-step list (default: `±1, ±8, ±16, ±64`).
+- `SellMenuLayoutConfiguration.quantityAdjustmentSlots` / `quantityDisplay` layout fields; inventory expanded from 27 to 36 slots to accommodate the extra row.
+
+### Fixed
+
+- Price-adjustment button labels displayed "coins" instead of the configured currency symbol (`$` by default). Labels now use `formatCurrency()` consistently with the rest of the sell menu.
+
+---
+
+## [2.0.1] - 2025-10-05
+
+### Added
+
+- **Orders-Only Mode**: set `orders-only-mode: true` in `orders-only.yml` to disable all auction-house features and expose only the `/orders` and `/order` buy-order commands.
+
+---
+
+## [2.0.0] - 2025-08-20
+
+### Added
+
+- Enhanced GUI navigation with Back buttons and search tips.
+- Quick access to pending returns via a dedicated Claims button.
+- Consolidated "My Activity" menu combining listings and history.
+- Low-price warning in listing confirmation dialogs.
+- EzShops 2.0.0+ integration support.
+
+### Changed
+
+- Full rewrite of GUI layer using Bukkit inventory-based menus with PDC-backed action keys.
+- Configuration split into focused files: `auction.yml`, `auction-storage.yml`, `auction-values.yml`, `discord.yml`, `orders-only.yml`.
+- Storage backend abstracted behind `AuctionStorage` interface; YAML and MySQL both supported.
+- Messages migrated to MiniMessage / Kyori Adventure components; legacy `§` colour codes removed.
+- Multi-language support formalised (`en`, `es`, `nl`, `zh`) via `language:` setting in `auction.yml`.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/Gyvex/ezauction/actions)
-[![Java](https://img.shields.io/badge/java-17%2B-blue)](https://adoptium.net/)
+[![Java](https://img.shields.io/badge/java-21%2B-blue)](https://adoptium.net/)
 
 **EzAuction** is a modern, extensible Minecraft auction plugin for Bukkit/Spigot servers. It features a user-friendly GUI, robust API, and comprehensive event system for both server owners and plugin developers.
 
-**Version 2.0.0** introduces enhanced GUI navigation, detailed confirmation dialogs, and full compatibility with EzShops 2.0.0+.
+**Version 2.0.0** introduced enhanced GUI navigation, detailed confirmation dialogs, and full compatibility with EzShops 2.0.0+. **Version 2.2.0** adds Team Auctions — team-scoped listings visible and purchasable only by your team, powered by the optional [TeamsAPI](https://github.com/ez-plugins/teams-api) soft-dependency.
 
 ---
 
@@ -30,8 +30,8 @@
 ---
 
 ## 📦 Requirements
-- Java 17 or higher ([Adoptium](https://adoptium.net/))
-- Bukkit/Spigot/Paper server (1.17+ recommended)
+- Java 21 or higher ([Adoptium](https://adoptium.net/))
+- Paper server 1.21+ (Bukkit/Spigot compatible)
 
 ## 🚀 Installation
 
@@ -58,6 +58,7 @@
 - Actively maintained and open source
 - **NEW in 2.0.1** Orders-Only Mode
   If you only want the Orders feature (buy orders, no auction house), set `orders-only-mode: true` in `orders-only.yml`. This disables all auction house features and enables the `/orders` and `/order` commands for players to create and manage buy orders.
+- **NEW in 2.2.0**: Team Auctions — team-scoped listings visible and purchasable only by members of the seller's team. Requires the optional [TeamsAPI](https://github.com/ez-plugins/teams-api) soft-dependency. Toggle with `team-auctions.enabled` in `auction.yml`.
 
 ## ⚙️ Configuration
 Default configuration files are generated on first run in `plugins/EzAuction/`.
@@ -93,6 +94,8 @@ When `orders-only-mode` is enabled, all other auction commands are disabled.
 | `/auction cancel`      | Cancel your active listing         | `ezauction.cancel`        |
 | `/auction reload`      | Reload plugin configuration        | `ezauction.admin.reload`  |
 | `/auction history [player]` | View your auction history (or another player's, if permitted) | `ezauction.auction.history` / `ezauction.auction.history.others` |
+| `/auction team`             | Browse team-scoped auction listings                           | `ezauction.auction.team`                                          |
+| `/auction team sell`        | List held item as a team auction                              | `ezauction.auction.team.sell`                                     |
 
 **Key Permissions:**
 
@@ -103,6 +106,8 @@ When `orders-only-mode` is enabled, all other auction commands are disabled.
 
 - `ezauction.auction.history`: View your own auction history in the GUI
 - `ezauction.auction.history.others`: View other players' auction history (if permitted)
+- `ezauction.auction.team`: Browse team-scoped auction listings (hidden when disabled or TeamsAPI absent)
+- `ezauction.auction.team.sell`: Create team-scoped listings via `/auction team sell`
 
 See the [docs/permissions.md](docs/permissions.md) for a full list.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See the [docs/permissions.md](docs/permissions.md) for a full list.
 - [Event Reference](docs/events.md): All plugin events, listener registration, and event payloads
 - [Configuration Guide](docs/configuration.md): All config options explained
 - [Permissions](docs/permissions.md): All permissions and their usage
+- [Changelog](CHANGELOG.md): Version history and notable changes
 - [Full Documentation](docs/): Guides, advanced usage, and troubleshooting
 
 ## 🛠️ Usage Examples

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,4 +173,20 @@ Version 2.0.0 adds support for EzShops 2.0.0+ while maintaining backwards compat
 
 ---
 
+## Team Auctions (`auction.yml`)
+
+Requires the [TeamsAPI](https://github.com/ez-plugins/teams-api) soft-dependency to be installed on the server. When the soft-dependency is absent or the toggle is off, the feature degrades gracefully — the GUI button is hidden and all team-auction commands are disabled.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `team-auctions.enabled` | boolean | `true` | Master toggle. Set to `false` to disable team-scoped auction listings server-wide. The GUI toggle button is also hidden when TeamsAPI is unavailable at runtime. |
+
+When `team-auctions.enabled` is `true` **and** TeamsAPI is present at runtime:
+
+- A **Team Auctions** toggle button appears in the browser GUI (configurable via `menu-layout_*.yml` under `toggles.team-listings`, default slot 50).
+- Players can use `/auction team` to browse their team's listings and `/auction team sell` to create a team-scoped listing.
+- Team listings are hidden from the global browse view and visible only to members of the seller's team.
+
+---
+
 For further help, see the README or open an issue on GitHub.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -16,6 +16,8 @@ This document lists all permissions available in the EzAuction plugin, their def
 | `ezauction.bypass.duration`   | op        | Bypass max listing duration restriction.          |
 | `ezauction.hologram`          | true      | Allows use of auction hologram commands.          |
 | `ezauction.live`              | true      | Allows use of live auction commands.              |
+| `ezauction.auction.team`      | true      | Allows browsing team-scoped auction listings.     |
+| `ezauction.auction.team.sell` | true      | Allows creating team-scoped auction listings.     |
 
 ## Permission Details
 
@@ -29,6 +31,8 @@ This document lists all permissions available in the EzAuction plugin, their def
 - **`ezauction.bypass.duration`**: Allows a player to set listing durations beyond the configured maximum.
 - **`ezauction.hologram`**: Allows use of commands related to auction holograms (if enabled).
 - **`ezauction.live`**: Allows use of live auction features and commands.
+- **`ezauction.auction.team`**: Required to browse the team auction view. Players without this permission will not see the team toggle button.
+- **`ezauction.auction.team.sell`**: Required to create team-scoped listings via `/auction team sell`. Requires TeamsAPI soft-dependency.
 
 ## Example Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.skyblockexp</groupId>
     <artifactId>ezauction</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <name>EzAuction Plugin</name>
     <description>Standalone auction house plugin for many of your advanced auction features.</description>
     <packaging>jar</packaging>
@@ -57,6 +57,12 @@
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ez-plugins</groupId>
+            <artifactId>teams-api</artifactId>
+            <version>1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -191,7 +197,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/skyblockexp/ezauction/AuctionListing.java
+++ b/src/main/java/com/skyblockexp/ezauction/AuctionListing.java
@@ -6,6 +6,9 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * Represents a single auction listing.
+ *
+ * <p>A listing is considered <em>team-scoped</em> when {@link #teamId()} is non-null.
+ * Team-scoped listings are only visible and purchasable by members of that team.</p>
  */
 public record AuctionListing(
         String id,
@@ -13,7 +16,8 @@ public record AuctionListing(
         double price,
         long expiryEpochMillis,
         ItemStack item,
-        double deposit) {
+        double deposit,
+        /* @Nullable */ UUID teamId) {
 
     public AuctionListing {
         Objects.requireNonNull(id, "id");
@@ -25,6 +29,21 @@ public record AuctionListing(
     @Override
     public ItemStack item() {
         return item != null ? item.clone() : null;
+    }
+
+    /**
+     * Returns {@code true} if this listing is restricted to members of a specific team.
+     */
+    public boolean isTeamListing() {
+        return teamId != null;
+    }
+
+    /**
+     * Convenience factory that creates a global (non-team) listing with a {@code null} teamId.
+     */
+    public static AuctionListing global(String id, UUID sellerId, double price, long expiryEpochMillis,
+            ItemStack item, double deposit) {
+        return new AuctionListing(id, sellerId, price, expiryEpochMillis, item, deposit, null);
     }
 
     public boolean isExpired() {

--- a/src/main/java/com/skyblockexp/ezauction/AuctionManager.java
+++ b/src/main/java/com/skyblockexp/ezauction/AuctionManager.java
@@ -4,6 +4,7 @@ import com.skyblockexp.ezauction.api.AuctionListingLimitResolver;
 import com.skyblockexp.ezauction.config.AuctionConfiguration;
 import com.skyblockexp.ezauction.config.AuctionBackendMessages;
 import com.skyblockexp.ezauction.config.AuctionListingRules;
+import com.skyblockexp.ezauction.integration.TeamsIntegration;
 import com.skyblockexp.ezauction.live.LiveAuctionEntry;
 import com.skyblockexp.ezauction.live.LiveAuctionService;
 import com.skyblockexp.ezauction.storage.AuctionStorage;
@@ -42,6 +43,8 @@ public class AuctionManager {
     // Config and resolver for listing limits
     private final AuctionConfiguration configuration;
     private final AuctionListingLimitResolver listingLimitResolver;
+    // Optional TeamsAPI integration
+    private final TeamsIntegration teamsIntegration;
 
     public AuctionManager(JavaPlugin plugin,
                          AuctionListingService listingService,
@@ -51,6 +54,19 @@ public class AuctionManager {
                          AuctionQueryService queryService,
                          AuctionConfiguration configuration,
                          AuctionListingLimitResolver listingLimitResolver) {
+        this(plugin, listingService, orderService, returnService, expiryService, queryService,
+                configuration, listingLimitResolver, null);
+    }
+
+    public AuctionManager(JavaPlugin plugin,
+                         AuctionListingService listingService,
+                         AuctionOrderService orderService,
+                         AuctionReturnService returnService,
+                         AuctionExpiryService expiryService,
+                         AuctionQueryService queryService,
+                         AuctionConfiguration configuration,
+                         AuctionListingLimitResolver listingLimitResolver,
+                         TeamsIntegration teamsIntegration) {
         this.plugin = plugin;
         this.listingService = listingService;
         this.orderService = orderService;
@@ -59,6 +75,7 @@ public class AuctionManager {
         this.queryService = queryService;
         this.configuration = configuration;
         this.listingLimitResolver = listingLimitResolver;
+        this.teamsIntegration = teamsIntegration;
     }
 
     /**
@@ -378,4 +395,58 @@ public class AuctionManager {
         }
         return result;
     }
-}
+
+    /**
+     * Returns active listings scoped to the team of the given player.
+     * Returns an empty list if the player is not in a team, team auctions are disabled,
+     * or TeamsAPI is unavailable.
+     *
+     * @param viewerId the UUID of the viewing player
+     * @return an unmodifiable list of team-scoped active listings
+     */
+    public List<AuctionListing> listActiveTeamListings(UUID viewerId) {
+        return queryService.listActiveTeamListings(viewerId);
+    }
+
+    /**
+     * Creates a team-scoped listing for the given seller.
+     * The listing will only be visible and purchasable by members of the seller's team.
+     *
+     * @param seller   the player creating the listing
+     * @param item     the item to list
+     * @param price    the listing price
+     * @param duration the duration
+     * @return the operation result
+     */
+    public AuctionOperationResult createTeamListing(Player seller, ItemStack item, double price, Duration duration) {
+        if (!isTeamAuctionsAvailable()) {
+            return AuctionOperationResult.failure("Team auctions are not available on this server.");
+        }
+        UUID teamId = teamsIntegration.getTeamId(seller.getUniqueId()).orElse(null);
+        if (teamId == null) {
+            return AuctionOperationResult.failure("You must be in a team to create a team listing.");
+        }
+        return listingService.createListing(seller, item, price, duration, teamId);
+    }
+
+    /**
+     * Returns {@code true} when team auctions are both enabled in config and TeamsAPI is available.
+     *
+     * @return {@code true} if team auctions can be used
+     */
+    public boolean isTeamAuctionsAvailable() {
+        return teamsIntegration != null
+                && teamsIntegration.isAvailable()
+                && configuration != null
+                && configuration.teamAuctionsEnabled();
+    }
+
+    /**
+     * Finds a listing by id regardless of team scope.
+     *
+     * @param listingId the listing id
+     * @return the listing, or {@code null} if not found
+     */
+    public AuctionListing findListingById(String listingId) {
+        return queryService.findListingById(listingId);
+    }}

--- a/src/main/java/com/skyblockexp/ezauction/bootstrap/component/ServiceSetupComponent.java
+++ b/src/main/java/com/skyblockexp/ezauction/bootstrap/component/ServiceSetupComponent.java
@@ -30,6 +30,7 @@ public class ServiceSetupComponent {
         public final Map<UUID, List<org.bukkit.inventory.ItemStack>> pendingReturns;
         public final com.skyblockexp.ezauction.integration.DiscordIntegration discordIntegration;
         public final com.skyblockexp.ezauction.claim.AuctionClaimService claimService;
+        public final com.skyblockexp.ezauction.integration.TeamsIntegration teamsIntegration;
         public ServiceSetupResult(
             AuctionTransactionService transactionService,
             AuctionTransactionHistory transactionHistory,
@@ -37,7 +38,8 @@ public class ServiceSetupComponent {
             AuctionManager auctionManager,
             Map<UUID, List<org.bukkit.inventory.ItemStack>> pendingReturns,
             com.skyblockexp.ezauction.integration.DiscordIntegration discordIntegration,
-            com.skyblockexp.ezauction.claim.AuctionClaimService claimService
+            com.skyblockexp.ezauction.claim.AuctionClaimService claimService,
+            com.skyblockexp.ezauction.integration.TeamsIntegration teamsIntegration
         ) {
             this.transactionService = transactionService;
             this.transactionHistory = transactionHistory;
@@ -46,6 +48,7 @@ public class ServiceSetupComponent {
             this.pendingReturns = pendingReturns;
             this.discordIntegration = discordIntegration;
             this.claimService = claimService;
+            this.teamsIntegration = teamsIntegration;
         }
     }
 
@@ -90,11 +93,12 @@ public class ServiceSetupComponent {
             listingLimitResolver = com.skyblockexp.ezauction.api.AuctionListingLimitResolver.useBaseLimit();
         }
         com.skyblockexp.ezauction.integration.DiscordIntegration discordIntegration = new com.skyblockexp.ezauction.integration.DiscordIntegration(plugin);
+        com.skyblockexp.ezauction.integration.TeamsIntegration teamsIntegration = new com.skyblockexp.ezauction.integration.TeamsIntegration(plugin);
         com.skyblockexp.ezauction.notification.AuctionNotificationService notificationService = new com.skyblockexp.ezauction.notification.AuctionNotificationService(plugin, configuration.backendMessages(), transactionService);
         com.skyblockexp.ezauction.claim.AuctionClaimService claimService = new com.skyblockexp.ezauction.claim.AuctionClaimService(pendingReturns, configuration.backendMessages());
         com.skyblockexp.ezauction.history.AuctionTransactionHistoryService transactionHistoryService = new com.skyblockexp.ezauction.history.AuctionTransactionHistoryService(transactionHistory, plugin, configuration.backendMessages().fallback());
         com.skyblockexp.ezauction.service.AuctionListingService listingService = new com.skyblockexp.ezauction.service.AuctionListingService(
-            transactionService, listingLimitResolver, configuration, configuration.listingRules(), liveAuctionService, persistenceManager, notificationService, claimService, transactionHistoryService, pendingReturns, listings, orders
+            transactionService, listingLimitResolver, configuration, configuration.listingRules(), liveAuctionService, persistenceManager, notificationService, claimService, transactionHistoryService, pendingReturns, listings, orders, teamsIntegration
         );
         com.skyblockexp.ezauction.service.AuctionOrderService orderService = new com.skyblockexp.ezauction.service.AuctionOrderService(
             transactionService, configuration.listingRules(), persistenceManager, notificationService, transactionHistoryService, claimService, pendingReturns, listings, orders
@@ -105,10 +109,10 @@ public class ServiceSetupComponent {
             configuration.backendMessages()
         );
         com.skyblockexp.ezauction.service.AuctionExpiryService expiryService = new com.skyblockexp.ezauction.service.AuctionExpiryService(plugin, listings, orders, persistenceManager, notificationService, transactionHistoryService, claimService, transactionService, pendingReturns);
-        com.skyblockexp.ezauction.service.AuctionQueryService queryService = new com.skyblockexp.ezauction.service.AuctionQueryService(listings, orders, liveAuctionService, configuration);
-        AuctionManager auctionManager = new AuctionManager(plugin, listingService, orderService, returnService, expiryService, queryService, configuration, listingLimitResolver);
+        com.skyblockexp.ezauction.service.AuctionQueryService queryService = new com.skyblockexp.ezauction.service.AuctionQueryService(listings, orders, liveAuctionService, configuration, teamsIntegration);
+        AuctionManager auctionManager = new AuctionManager(plugin, listingService, orderService, returnService, expiryService, queryService, configuration, listingLimitResolver, teamsIntegration);
         auctionManager.enable();
         liveAuctionService.enable();
-        return new ServiceSetupResult(transactionService, transactionHistory, liveAuctionService, auctionManager, pendingReturns, discordIntegration, claimService);
+        return new ServiceSetupResult(transactionService, transactionHistory, liveAuctionService, auctionManager, pendingReturns, discordIntegration, claimService, teamsIntegration);
     }
 }

--- a/src/main/java/com/skyblockexp/ezauction/command/AuctionCommand.java
+++ b/src/main/java/com/skyblockexp/ezauction/command/AuctionCommand.java
@@ -15,6 +15,7 @@ import com.skyblockexp.ezauction.config.AuctionCommandMessageConfiguration;
 import com.skyblockexp.ezauction.gui.AuctionMenu;
 import com.skyblockexp.ezauction.gui.AuctionOrderMenu;
 import com.skyblockexp.ezauction.gui.AuctionSellMenu;
+import com.skyblockexp.ezauction.gui.BrowserView;
 import com.skyblockexp.ezauction.gui.LiveAuctionMenu;
 import com.skyblockexp.ezauction.gui.SellMenuHolder.Target;
 
@@ -149,6 +150,11 @@ public class AuctionCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (subcommand.equals("team")) {
+            handleTeam(player, label, args);
+            return true;
+        }
+
         sendUsage(player, label);
         return true;
     }
@@ -254,6 +260,26 @@ public class AuctionCommand implements CommandExecutor, TabCompleter {
             return;
         }
         liveAuctionMenu.open(player);
+    }
+
+    private void handleTeam(Player player, String label, String[] args) {
+        if (!player.hasPermission("ezauction.auction.team")) {
+            sendMessage(player, ChatColor.RED + "You do not have permission to use team auctions.");
+            return;
+        }
+        if (!auctionManager.isTeamAuctionsAvailable()) {
+            sendMessage(player, ChatColor.RED + "Team auctions are not available on this server.");
+            return;
+        }
+        if (args.length >= 2 && args[1].equalsIgnoreCase("sell")) {
+            if (!player.hasPermission("ezauction.auction.team.sell")) {
+                sendMessage(player, ChatColor.RED + "You do not have permission to create team auction listings.");
+                return;
+            }
+            auctionSellMenu.openTeamSell(player);
+            return;
+        }
+        auctionMenu.openBrowser(player, BrowserView.TEAM_LISTINGS, 0);
     }
 
     private void sendUsage(Player player, String label) {

--- a/src/main/java/com/skyblockexp/ezauction/command/AuctionCommand.java
+++ b/src/main/java/com/skyblockexp/ezauction/command/AuctionCommand.java
@@ -659,7 +659,7 @@ public class AuctionCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return filter(args[0], List.of("sell", "order", "cancel", "history", "claim", "live"));
+            return filter(args[0], List.of("sell", "order", "cancel", "history", "claim", "live", "team"));
         }
 
         if (args.length == 2 && args[0].equalsIgnoreCase("sell")) {
@@ -700,6 +700,13 @@ public class AuctionCommand implements CommandExecutor, TabCompleter {
 
         if (args.length == 2 && args[0].equalsIgnoreCase("history")) {
             return filter(args[1], List.of("buy", "sell"));
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("team")) {
+            if (auctionManager.isTeamAuctionsAvailable() && sender.hasPermission("ezauction.auction.team.sell")) {
+                return filter(args[1], List.of("sell"));
+            }
+            return Collections.emptyList();
         }
 
         return Collections.emptyList();

--- a/src/main/java/com/skyblockexp/ezauction/config/AuctionConfiguration.java
+++ b/src/main/java/com/skyblockexp/ezauction/config/AuctionConfiguration.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 public final class AuctionConfiguration {
     private final boolean debug;
+    private final boolean teamAuctionsEnabled;
 
     private final int baseListingLimit;
     private final AuctionStorageConfiguration storageConfiguration;
@@ -34,6 +35,20 @@ public final class AuctionConfiguration {
             AuctionHologramConfiguration hologramConfiguration,
             LiveAuctionConfiguration liveAuctionConfiguration, List<Duration> durationOptions,
             boolean debug) {
+        this(baseListingLimit, storageConfiguration, listingRules, menuConfiguration, menuInteractionConfiguration,
+                valueConfiguration, messageConfiguration, backendMessages, commandMessageConfiguration,
+                hologramConfiguration, liveAuctionConfiguration, durationOptions, debug, true);
+    }
+
+        public AuctionConfiguration(int baseListingLimit, AuctionStorageConfiguration storageConfiguration,
+            AuctionListingRules listingRules, AuctionMenuConfiguration menuConfiguration,
+            AuctionMenuInteractionConfiguration menuInteractionConfiguration,
+            AuctionValueConfiguration valueConfiguration, AuctionMessageConfiguration messageConfiguration,
+            AuctionBackendMessages backendMessages,
+            AuctionCommandMessageConfiguration commandMessageConfiguration,
+            AuctionHologramConfiguration hologramConfiguration,
+            LiveAuctionConfiguration liveAuctionConfiguration, List<Duration> durationOptions,
+            boolean debug, boolean teamAuctionsEnabled) {
         this.baseListingLimit = Math.max(0, baseListingLimit);
         this.storageConfiguration = storageConfiguration != null
                 ? storageConfiguration
@@ -61,10 +76,15 @@ public final class AuctionConfiguration {
                 : LiveAuctionConfiguration.defaults();
         this.durationOptions = sanitizeDurationOptions(durationOptions);
         this.debug = debug;
+        this.teamAuctionsEnabled = teamAuctionsEnabled;
     }
 
     public boolean debug() {
         return debug;
+    }
+
+    public boolean teamAuctionsEnabled() {
+        return teamAuctionsEnabled;
     }
 
     public int baseListingLimit() {
@@ -120,7 +140,7 @@ public final class AuctionConfiguration {
                 AuctionMenuConfiguration.defaults(), AuctionMenuInteractionConfiguration.defaults(),
                 AuctionValueConfiguration.defaults(), AuctionMessageConfiguration.defaults(),
                 AuctionBackendMessages.defaults(), AuctionCommandMessageConfiguration.defaults(),
-                AuctionHologramConfiguration.defaults(), LiveAuctionConfiguration.defaults(), List.of(), false);
+                AuctionHologramConfiguration.defaults(), LiveAuctionConfiguration.defaults(), List.of(), false, true);
     }
 
     /**

--- a/src/main/java/com/skyblockexp/ezauction/config/AuctionConfigurationLoader.java
+++ b/src/main/java/com/skyblockexp/ezauction/config/AuctionConfigurationLoader.java
@@ -88,11 +88,12 @@ public final class AuctionConfigurationLoader {
         ConfigurationSection liveAuctionSection = getSection(baseConfiguration, "live-auctions");
         LiveAuctionConfiguration liveAuctionConfiguration = LiveAuctionConfiguration.from(liveAuctionSection);
 
+        boolean debug = baseConfiguration != null && baseConfiguration.isBoolean("debug") && baseConfiguration.getBoolean("debug");
+        boolean teamAuctionsEnabled = baseConfiguration == null || baseConfiguration.getBoolean("team-auctions.enabled", true);
         AuctionConfiguration result = new AuctionConfiguration(baseLimit, storageConfiguration, listingRules,
                 menuConfiguration, menuInteractionConfiguration, valueConfiguration, messageConfiguration,
                 backendMessages, commandMessageConfiguration, hologramConfiguration, liveAuctionConfiguration,
-                durationOptions,
-                baseConfiguration != null && baseConfiguration.isBoolean("debug") ? baseConfiguration.getBoolean("debug") : false);
+                durationOptions, debug, teamAuctionsEnabled);
         plugin.getLogger().log(Level.CONFIG, "Loaded auction configuration: {0}", result);
         return result;
     }

--- a/src/main/java/com/skyblockexp/ezauction/config/AuctionMenuConfiguration.java
+++ b/src/main/java/com/skyblockexp/ezauction/config/AuctionMenuConfiguration.java
@@ -22,6 +22,7 @@ public final class AuctionMenuConfiguration {
     private static final int DEFAULT_BROWSER_EMPTY_LISTING_SLOT = 22;
     private static final int DEFAULT_BROWSER_LISTINGS_TOGGLE_SLOT = 46;
     private static final int DEFAULT_BROWSER_ORDERS_TOGGLE_SLOT = 52;
+    private static final int DEFAULT_BROWSER_TEAM_LISTINGS_TOGGLE_SLOT = 50;
         private static final ToggleButtonConfiguration DEFAULT_BROWSER_LISTINGS_TOGGLE =
             new ToggleButtonConfiguration(
                 DEFAULT_BROWSER_LISTINGS_TOGGLE_SLOT,
@@ -36,6 +37,13 @@ public final class AuctionMenuConfiguration {
                     Material.PAPER,
                     "&aBuy Orders",
                     List.of("&7Browse active buy orders.")));
+        private static final ToggleButtonConfiguration DEFAULT_BROWSER_TEAM_LISTINGS_TOGGLE =
+            new ToggleButtonConfiguration(
+                DEFAULT_BROWSER_TEAM_LISTINGS_TOGGLE_SLOT,
+                new MenuButtonConfiguration(
+                    Material.SHIELD,
+                    "&bTeam Auctions",
+                    List.of("&7Browse your team's listings.")));
         private static final BrowserMenuConfiguration.SearchButtonConfiguration DEFAULT_BROWSER_SEARCH_BUTTON =
             new BrowserMenuConfiguration.SearchButtonConfiguration(
                 48,
@@ -97,6 +105,7 @@ public final class AuctionMenuConfiguration {
             DEFAULT_BROWSER_EMPTY_LISTING_SLOT,
             DEFAULT_BROWSER_LISTINGS_TOGGLE,
             DEFAULT_BROWSER_ORDERS_TOGGLE,
+            DEFAULT_BROWSER_TEAM_LISTINGS_TOGGLE,
             DEFAULT_BROWSER_SEARCH_BUTTON,
             DEFAULT_BROWSER_SORT_BUTTON,
             DEFAULT_BROWSER_SEARCH_TIPS_BUTTON,
@@ -316,6 +325,7 @@ public final class AuctionMenuConfiguration {
         private final int emptyListingSlot;
         private final ToggleButtonConfiguration listingsToggle;
         private final ToggleButtonConfiguration ordersToggle;
+        private final ToggleButtonConfiguration teamListingsToggle;
         private final SearchButtonConfiguration searchButton;
         private final SortButtonConfiguration sortButton;
         private final SearchTipsButtonConfiguration searchTipsButton;
@@ -323,7 +333,8 @@ public final class AuctionMenuConfiguration {
 
         private BrowserMenuConfiguration(String title, int size, MenuButtonConfiguration filler, int previousSlot,
                 int closeSlot, int nextSlot, int emptyListingSlot, ToggleButtonConfiguration listingsToggle,
-                ToggleButtonConfiguration ordersToggle, SearchButtonConfiguration searchButton,
+                ToggleButtonConfiguration ordersToggle, ToggleButtonConfiguration teamListingsToggle,
+                SearchButtonConfiguration searchButton,
                 SortButtonConfiguration sortButton, SearchTipsButtonConfiguration searchTipsButton,
                 ClaimsButtonConfiguration claimsButton) {
             this.title = title != null ? title : DEFAULT_BROWSER_TITLE;
@@ -336,6 +347,7 @@ public final class AuctionMenuConfiguration {
             this.emptyListingSlot = sanitizeSlot(emptyListingSlot, sanitizedSize, DEFAULT_BROWSER_EMPTY_LISTING_SLOT);
             this.listingsToggle = sanitizeToggle(listingsToggle, sanitizedSize, DEFAULT_BROWSER_LISTINGS_TOGGLE);
             this.ordersToggle = sanitizeToggle(ordersToggle, sanitizedSize, DEFAULT_BROWSER_ORDERS_TOGGLE);
+            this.teamListingsToggle = sanitizeToggle(teamListingsToggle, sanitizedSize, DEFAULT_BROWSER_TEAM_LISTINGS_TOGGLE);
             this.searchButton = sanitizeSearchButton(searchButton, sanitizedSize, DEFAULT_BROWSER_SEARCH_BUTTON);
             this.sortButton = sanitizeSortButton(sortButton, sanitizedSize, DEFAULT_BROWSER_SORT_BUTTON);
             this.searchTipsButton = searchTipsButton != null ? searchTipsButton : DEFAULT_BROWSER_SEARCH_TIPS_BUTTON;
@@ -363,6 +375,8 @@ public final class AuctionMenuConfiguration {
                     section.getConfigurationSection("toggles.listings"), size, DEFAULT_BROWSER.listingsToggle);
             ToggleButtonConfiguration ordersToggle = ToggleButtonConfiguration.from(
                     section.getConfigurationSection("toggles.orders"), size, DEFAULT_BROWSER.ordersToggle);
+            ToggleButtonConfiguration teamListingsToggle = ToggleButtonConfiguration.from(
+                    section.getConfigurationSection("toggles.team-listings"), size, DEFAULT_BROWSER.teamListingsToggle);
             SearchButtonConfiguration searchButton = SearchButtonConfiguration.from(
                     section.getConfigurationSection("search"), size, DEFAULT_BROWSER.searchButton);
             SortButtonConfiguration sortButton = SortButtonConfiguration.from(
@@ -372,7 +386,7 @@ public final class AuctionMenuConfiguration {
             ClaimsButtonConfiguration claimsButton = ClaimsButtonConfiguration.from(
                     section.getConfigurationSection("claims"), size, DEFAULT_BROWSER.claimsButton);
             return new BrowserMenuConfiguration(title, size, filler, previous, close, next, emptySlot, listingsToggle,
-                    ordersToggle, searchButton, sortButton, searchTipsButton, claimsButton);
+                    ordersToggle, teamListingsToggle, searchButton, sortButton, searchTipsButton, claimsButton);
         }
 
         public String title() {
@@ -411,6 +425,10 @@ public final class AuctionMenuConfiguration {
             return ordersToggle;
         }
 
+        public ToggleButtonConfiguration teamListingsToggle() {
+            return teamListingsToggle;
+        }
+
         public SearchButtonConfiguration searchButton() {
             return searchButton;
         }
@@ -439,6 +457,7 @@ public final class AuctionMenuConfiguration {
                     + ", emptyListingSlot=" + emptyListingSlot
                     + ", listingsToggle=" + listingsToggle
                     + ", ordersToggle=" + ordersToggle
+                    + ", teamListingsToggle=" + teamListingsToggle
                     + ", searchButton=" + searchButton
                     + ", sortButton=" + sortButton
                     + ", searchTipsButton=" + searchTipsButton
@@ -463,6 +482,7 @@ public final class AuctionMenuConfiguration {
                     && Objects.equals(filler, that.filler)
                     && Objects.equals(listingsToggle, that.listingsToggle)
                     && Objects.equals(ordersToggle, that.ordersToggle)
+                    && Objects.equals(teamListingsToggle, that.teamListingsToggle)
                     && Objects.equals(searchButton, that.searchButton)
                     && Objects.equals(sortButton, that.sortButton)
                     && Objects.equals(searchTipsButton, that.searchTipsButton)
@@ -472,7 +492,7 @@ public final class AuctionMenuConfiguration {
         @Override
         public int hashCode() {
             return Objects.hash(title, size, filler, previousSlot, closeSlot, nextSlot, emptyListingSlot, listingsToggle,
-                    ordersToggle, searchButton, sortButton, searchTipsButton, claimsButton);
+                    ordersToggle, teamListingsToggle, searchButton, sortButton, searchTipsButton, claimsButton);
         }
 
         public static final class SearchButtonConfiguration {

--- a/src/main/java/com/skyblockexp/ezauction/config/AuctionMenuInteractionConfiguration.java
+++ b/src/main/java/com/skyblockexp/ezauction/config/AuctionMenuInteractionConfiguration.java
@@ -346,21 +346,24 @@ public final class AuctionMenuInteractionConfiguration {
     public static final class SellMenuLayoutConfiguration {
 
         private static final String DEFAULT_TITLE = "&2Create Auction Listing";
-        private static final int DEFAULT_SIZE = 27;
+        private static final int DEFAULT_SIZE = 36;
         private static final MenuButtonDefinition DEFAULT_FILLER =
                 MenuButtonDefinition.of(Material.GRAY_STAINED_GLASS_PANE, "&8 ");
-        private static final int DEFAULT_LISTING_SLOT = 11;
+        private static final int DEFAULT_LISTING_SLOT = 20;
         private static final ButtonLayoutConfiguration DEFAULT_PRICE_DISPLAY =
-                ButtonLayoutConfiguration.of(13, MenuButtonDefinition.of(Material.SUNFLOWER, "&6Listing Price"));
+                ButtonLayoutConfiguration.of(22, MenuButtonDefinition.of(Material.SUNFLOWER, "&6Listing Price"));
         private static final ButtonLayoutConfiguration DEFAULT_DURATION_DISPLAY =
-                ButtonLayoutConfiguration.of(15, MenuButtonDefinition.of(Material.CLOCK, "&eListing Duration"));
+                ButtonLayoutConfiguration.of(24, MenuButtonDefinition.of(Material.CLOCK, "&eListing Duration"));
         private static final ButtonLayoutConfiguration DEFAULT_CUSTOM_PRICE =
-                ButtonLayoutConfiguration.of(16, MenuButtonDefinition.of(Material.WRITABLE_BOOK, "&bCustom Price"));
+                ButtonLayoutConfiguration.of(25, MenuButtonDefinition.of(Material.WRITABLE_BOOK, "&bCustom Price"));
         private static final ButtonLayoutConfiguration DEFAULT_CONFIRM_BUTTON =
-                ButtonLayoutConfiguration.of(22, MenuButtonDefinition.of(Material.LIME_CONCRETE, "&aCreate Listing"));
+                ButtonLayoutConfiguration.of(31, MenuButtonDefinition.of(Material.LIME_CONCRETE, "&aCreate Listing"));
         private static final ButtonLayoutConfiguration DEFAULT_CANCEL_BUTTON =
-                ButtonLayoutConfiguration.of(24, MenuButtonDefinition.of(Material.RED_CONCRETE, "&cCancel"));
+                ButtonLayoutConfiguration.of(33, MenuButtonDefinition.of(Material.RED_CONCRETE, "&cCancel"));
         private static final int[] DEFAULT_PRICE_ADJUST_SLOTS = new int[] {0, 1, 2, 3, 5, 6, 7, 8};
+        private static final int[] DEFAULT_QUANTITY_ADJUST_SLOTS = new int[] {9, 10, 11, 12, 14, 15, 16, 17};
+        private static final ButtonLayoutConfiguration DEFAULT_QUANTITY_DISPLAY =
+                ButtonLayoutConfiguration.of(13, MenuButtonDefinition.of(Material.CHEST, "&bListing Amount"));
         private static final SellMenuLayoutConfiguration DEFAULT = new SellMenuLayoutConfiguration(
                 DEFAULT_TITLE,
                 DEFAULT_SIZE,
@@ -371,7 +374,9 @@ public final class AuctionMenuInteractionConfiguration {
                 DEFAULT_CUSTOM_PRICE,
                 DEFAULT_CONFIRM_BUTTON,
                 DEFAULT_CANCEL_BUTTON,
-                DEFAULT_PRICE_ADJUST_SLOTS);
+                DEFAULT_PRICE_ADJUST_SLOTS,
+                DEFAULT_QUANTITY_ADJUST_SLOTS,
+                DEFAULT_QUANTITY_DISPLAY);
 
         private final String title;
         private final int size;
@@ -383,11 +388,14 @@ public final class AuctionMenuInteractionConfiguration {
         private final ButtonLayoutConfiguration confirmButton;
         private final ButtonLayoutConfiguration cancelButton;
         private final int[] priceAdjustmentSlots;
+        private final int[] quantityAdjustmentSlots;
+        private final ButtonLayoutConfiguration quantityDisplay;
 
         private SellMenuLayoutConfiguration(String title, int size, MenuButtonDefinition filler, int listingSlot,
                 ButtonLayoutConfiguration priceDisplay, ButtonLayoutConfiguration durationDisplay,
                 ButtonLayoutConfiguration customPrice, ButtonLayoutConfiguration confirmButton,
-                ButtonLayoutConfiguration cancelButton, int[] priceAdjustmentSlots) {
+                ButtonLayoutConfiguration cancelButton, int[] priceAdjustmentSlots,
+                int[] quantityAdjustmentSlots, ButtonLayoutConfiguration quantityDisplay) {
             this.title = title != null ? title : DEFAULT_TITLE;
             int sanitizedSize = sanitizeInventorySize(size, DEFAULT_SIZE);
             this.size = sanitizedSize;
@@ -402,6 +410,10 @@ public final class AuctionMenuInteractionConfiguration {
             this.cancelButton = ButtonLayoutConfiguration.normalize(cancelButton, DEFAULT_CANCEL_BUTTON, sanitizedSize);
             this.priceAdjustmentSlots = sanitizeSlotsArray(priceAdjustmentSlots, sanitizedSize,
                     DEFAULT_PRICE_ADJUST_SLOTS);
+            this.quantityAdjustmentSlots = sanitizeSlotsArray(quantityAdjustmentSlots, sanitizedSize,
+                    DEFAULT_QUANTITY_ADJUST_SLOTS);
+            this.quantityDisplay = ButtonLayoutConfiguration.normalize(quantityDisplay, DEFAULT_QUANTITY_DISPLAY,
+                    sanitizedSize);
         }
 
         public static SellMenuLayoutConfiguration defaults() {
@@ -431,8 +443,12 @@ public final class AuctionMenuInteractionConfiguration {
                     section.getConfigurationSection("cancel"), DEFAULT_CANCEL_BUTTON, size);
             int[] priceAdjustSlots = sanitizeSlots(section.getList("price-adjust.slots"), size,
                     DEFAULT_PRICE_ADJUST_SLOTS);
+            int[] quantityAdjustSlots = sanitizeSlots(section.getList("quantity-adjust.slots"), size,
+                    DEFAULT_QUANTITY_ADJUST_SLOTS);
+            ButtonLayoutConfiguration quantityDisplay = ButtonLayoutConfiguration.from(
+                    section.getConfigurationSection("quantity-display"), DEFAULT_QUANTITY_DISPLAY, size);
             return new SellMenuLayoutConfiguration(title, size, filler, listingSlot, priceDisplay, durationDisplay,
-                    customPrice, confirm, cancel, priceAdjustSlots);
+                    customPrice, confirm, cancel, priceAdjustSlots, quantityAdjustSlots, quantityDisplay);
         }
 
         public String title() {
@@ -475,6 +491,14 @@ public final class AuctionMenuInteractionConfiguration {
             return priceAdjustmentSlots.clone();
         }
 
+        public int[] quantityAdjustmentSlots() {
+            return quantityAdjustmentSlots.clone();
+        }
+
+        public ButtonLayoutConfiguration quantityDisplay() {
+            return quantityDisplay;
+        }
+
         @Override
         public String toString() {
             return "SellMenuLayoutConfiguration{"
@@ -488,6 +512,8 @@ public final class AuctionMenuInteractionConfiguration {
                     + ", confirmButton=" + confirmButton
                     + ", cancelButton=" + cancelButton
                     + ", priceAdjustmentSlots=" + Arrays.toString(priceAdjustmentSlots)
+                    + ", quantityAdjustmentSlots=" + Arrays.toString(quantityAdjustmentSlots)
+                    + ", quantityDisplay=" + quantityDisplay
                     + '}';
         }
 
@@ -508,14 +534,17 @@ public final class AuctionMenuInteractionConfiguration {
                     && Objects.equals(customPrice, that.customPrice)
                     && Objects.equals(confirmButton, that.confirmButton)
                     && Objects.equals(cancelButton, that.cancelButton)
-                    && Arrays.equals(priceAdjustmentSlots, that.priceAdjustmentSlots);
+                    && Arrays.equals(priceAdjustmentSlots, that.priceAdjustmentSlots)
+                    && Arrays.equals(quantityAdjustmentSlots, that.quantityAdjustmentSlots)
+                    && Objects.equals(quantityDisplay, that.quantityDisplay);
         }
 
         @Override
         public int hashCode() {
             int result = Objects.hash(title, size, filler, listingSlot, priceDisplay, durationDisplay, customPrice,
-                    confirmButton, cancelButton);
+                    confirmButton, cancelButton, quantityDisplay);
             result = 31 * result + Arrays.hashCode(priceAdjustmentSlots);
+            result = 31 * result + Arrays.hashCode(quantityAdjustmentSlots);
             return result;
         }
     }
@@ -528,15 +557,18 @@ public final class AuctionMenuInteractionConfiguration {
         private static final double DEFAULT_PRICE = 100.0D;
         private static final List<Double> DEFAULT_ADJUSTMENTS = List.of(-1000.0D, -100.0D, -10.0D, -1.0D, 1.0D, 10.0D,
                 100.0D, 1000.0D);
+        private static final List<Integer> DEFAULT_QUANTITY_ADJUSTMENTS = List.of(-64, -16, -8, -1, 1, 8, 16, 64);
 
         private final double defaultPrice;
         private final List<Double> priceAdjustments;
+        private final List<Integer> quantityAdjustments;
         private final SellMenuLayoutConfiguration layout;
 
         private SellMenuInteractionConfiguration(double defaultPrice, List<Double> priceAdjustments,
-                SellMenuLayoutConfiguration layout) {
+                List<Integer> quantityAdjustments, SellMenuLayoutConfiguration layout) {
             this.defaultPrice = defaultPrice;
             this.priceAdjustments = priceAdjustments;
+            this.quantityAdjustments = quantityAdjustments;
             this.layout = layout != null ? layout : SellMenuLayoutConfiguration.defaults();
         }
 
@@ -546,6 +578,10 @@ public final class AuctionMenuInteractionConfiguration {
 
         public List<Double> priceAdjustments() {
             return priceAdjustments;
+        }
+
+        public List<Integer> quantityAdjustments() {
+            return quantityAdjustments;
         }
 
         public SellMenuLayoutConfiguration layout() {
@@ -564,9 +600,10 @@ public final class AuctionMenuInteractionConfiguration {
                 }
             }
             List<Double> adjustments = sanitizePriceAdjustments(section.getList("price-adjustments"));
+            List<Integer> quantityAdjustments = sanitizeQuantityAdjustments(section.getList("quantity-adjustments"));
             SellMenuLayoutConfiguration layout = SellMenuLayoutConfiguration
                     .from(section.getConfigurationSection("layout"));
-            return new SellMenuInteractionConfiguration(defaultPrice, adjustments, layout);
+            return new SellMenuInteractionConfiguration(defaultPrice, adjustments, quantityAdjustments, layout);
         }
 
         private static List<Double> sanitizePriceAdjustments(List<?> rawValues) {
@@ -586,9 +623,26 @@ public final class AuctionMenuInteractionConfiguration {
             return List.copyOf(parsed);
         }
 
+        private static List<Integer> sanitizeQuantityAdjustments(List<?> rawValues) {
+            if (rawValues == null || rawValues.isEmpty()) {
+                return DEFAULT_QUANTITY_ADJUSTMENTS;
+            }
+            List<Integer> parsed = new ArrayList<>();
+            for (Object rawValue : rawValues) {
+                Integer parsedValue = parseInteger(rawValue);
+                if (parsedValue != null && parsedValue != 0) {
+                    parsed.add(parsedValue);
+                }
+            }
+            if (parsed.isEmpty()) {
+                return DEFAULT_QUANTITY_ADJUSTMENTS;
+            }
+            return List.copyOf(parsed);
+        }
+
         private static SellMenuInteractionConfiguration defaults() {
             return new SellMenuInteractionConfiguration(DEFAULT_PRICE, DEFAULT_ADJUSTMENTS,
-                    SellMenuLayoutConfiguration.defaults());
+                    DEFAULT_QUANTITY_ADJUSTMENTS, SellMenuLayoutConfiguration.defaults());
         }
 
         @Override
@@ -596,6 +650,7 @@ public final class AuctionMenuInteractionConfiguration {
             return "SellMenuInteractionConfiguration{"
                     + "defaultPrice=" + defaultPrice
                     + ", priceAdjustments=" + priceAdjustments
+                    + ", quantityAdjustments=" + quantityAdjustments
                     + ", layout=" + layout
                     + '}';
         }
@@ -610,12 +665,13 @@ public final class AuctionMenuInteractionConfiguration {
             }
             return Double.compare(that.defaultPrice, defaultPrice) == 0
                     && Objects.equals(priceAdjustments, that.priceAdjustments)
+                    && Objects.equals(quantityAdjustments, that.quantityAdjustments)
                     && Objects.equals(layout, that.layout);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(defaultPrice, priceAdjustments, layout);
+            return Objects.hash(defaultPrice, priceAdjustments, quantityAdjustments, layout);
         }
     }
 

--- a/src/main/java/com/skyblockexp/ezauction/gui/AuctionMenu.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/AuctionMenu.java
@@ -64,6 +64,7 @@ public class AuctionMenu implements Listener {
     private static final String ACTION_CLOSE = "close";
     private static final String ACTION_TOGGLE_LISTINGS = "toggle_listings";
     private static final String ACTION_TOGGLE_ORDERS = "toggle_orders";
+    private static final String ACTION_TOGGLE_TEAM_LISTINGS = "toggle_team_listings";
     private static final String ACTION_SEARCH = "search";
     private static final String ACTION_SORT = "sort";
     private static final String ACTION_SEARCH_TIPS = "search_tips";
@@ -81,6 +82,7 @@ public class AuctionMenu implements Listener {
     private final AuctionMenuConfiguration.ConfirmMenuConfiguration confirmConfig;
     private final AuctionMenuConfiguration.ToggleButtonConfiguration listingsToggleConfig;
     private final AuctionMenuConfiguration.ToggleButtonConfiguration ordersToggleConfig;
+    private final AuctionMenuConfiguration.ToggleButtonConfiguration teamListingsToggleConfig;
     private final AuctionMenuConfiguration.BrowserMenuConfiguration.SearchButtonConfiguration searchButtonConfig;
     private final AuctionMenuConfiguration.BrowserMenuConfiguration.SortButtonConfiguration sortButtonConfig;
     private final AuctionMenuConfiguration.BrowserMenuConfiguration.SearchTipsButtonConfiguration searchTipsButtonConfig;
@@ -125,6 +127,7 @@ public class AuctionMenu implements Listener {
         this.confirmConfig = Objects.requireNonNull(menuConfiguration.confirm(), "confirmConfig");
         this.listingsToggleConfig = this.browserConfig.listingsToggle();
         this.ordersToggleConfig = this.browserConfig.ordersToggle();
+        this.teamListingsToggleConfig = this.browserConfig.teamListingsToggle();
         this.searchButtonConfig = this.browserConfig.searchButton();
         this.sortButtonConfig = this.browserConfig.sortButton();
         this.searchTipsButtonConfig = this.browserConfig.searchTipsButton();
@@ -167,18 +170,27 @@ public class AuctionMenu implements Listener {
         openBrowser(player, BrowserView.LISTINGS, 0);
     }
 
-    private void openBrowser(Player player, BrowserView view, int page) {
+    public void openBrowser(Player player, BrowserView view, int page) {
+        openBrowserInternal(player, view, page);
+    }
+
+    private void openBrowserInternal(Player player, BrowserView view, int page) {
         UUID playerId = player.getUniqueId();
         String searchQuery = getSearchQuery(playerId);
         String normalizedQuery = searchQuery != null ? searchQuery.toLowerCase(Locale.ENGLISH) : null;
 
-        List<AuctionListing> listings = view == BrowserView.LISTINGS
-            ? new ArrayList<>(auctionManager.listActiveListings())
-            : Collections.emptyList();
+        List<AuctionListing> listings;
+        if (view == BrowserView.LISTINGS) {
+            listings = new ArrayList<>(auctionManager.listActiveListings());
+        } else if (view == BrowserView.TEAM_LISTINGS) {
+            listings = new ArrayList<>(auctionManager.listActiveTeamListings(player.getUniqueId()));
+        } else {
+            listings = Collections.emptyList();
+        }
         if (view == BrowserView.LISTINGS && auctionManager != null && auctionManager.getConfiguration() != null && auctionManager.getConfiguration().debug()) {
             System.out.println("[EzAuction][DEBUG] AuctionMenu.openBrowser: listings.size() = " + listings.size() + ", listings = " + listings);
         }
-        if (view == BrowserView.LISTINGS) {
+        if (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) {
             filterListings(listings, normalizedQuery);
         }
         List<AuctionOrder> orders = view == BrowserView.ORDERS
@@ -190,14 +202,14 @@ public class AuctionMenu implements Listener {
 
         ListingSort listingSort = getListingSort(playerId);
         OrderSort orderSort = getOrderSort(playerId);
-        if (view == BrowserView.LISTINGS) {
+        if (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) {
             listingSort.sort(listings);
         }
         if (view == BrowserView.ORDERS) {
             orderSort.sort(orders);
         }
 
-        int totalEntries = view == BrowserView.LISTINGS ? listings.size() : orders.size();
+        int totalEntries = (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) ? listings.size() : orders.size();
         int entriesPerPage = Math.max(1, listingsPerPage);
         int totalPages = Math.max(1, (int) Math.ceil(totalEntries / (double) entriesPerPage));
         int currentPage = Math.max(0, Math.min(page, totalPages - 1));
@@ -219,13 +231,13 @@ public class AuctionMenu implements Listener {
                 emptyTitle = ChatColor.RED + "No Matches";
                 List<String> tempLore = new ArrayList<>();
                 tempLore.add(ChatColor.GRAY + "No "
-                        + (view == BrowserView.LISTINGS ? "listings" : "orders")
+                + ((view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) ? "listings" : "orders")
                         + " matched \"" + ChatColor.AQUA + formatSearchQueryForLore(searchQuery) + ChatColor.GRAY + "\".");
                 tempLore.add(ChatColor.YELLOW + "Right-click the search button to clear.");
                 lore = tempLore;
             } else {
-                emptyTitle = view == BrowserView.LISTINGS ? ChatColor.RED + "No Listings" : ChatColor.RED + "No Orders";
-                lore = view == BrowserView.LISTINGS
+                emptyTitle = (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) ? ChatColor.RED + "No Listings" : ChatColor.RED + "No Orders";
+                lore = (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS)
                         ? List.of(ChatColor.GRAY + "No items are currently listed.")
                         : List.of(ChatColor.GRAY + "No buy orders are currently active.");
             }
@@ -236,14 +248,14 @@ public class AuctionMenu implements Listener {
         } else {
             int slot = 0;
             for (int index = startIndex; index < endIndex; index++) {
-                if (view == BrowserView.LISTINGS) {
+                if (view == BrowserView.LISTINGS || view == BrowserView.TEAM_LISTINGS) {
                     AuctionListing listing = listings.get(index);
                     ItemStack icon = decorateListing(listing, playerId);
                     if (icon == null) {
                         continue;
                     }
                     setPersistent(icon, actionKey, ACTION_LISTING);
-                    setPersistent(icon, actionTypeKey, BrowserView.LISTINGS.name());
+                    setPersistent(icon, actionTypeKey, view.name());
                     setPersistent(icon, listingKey, listing.id());
                     if (slot < inventory.getSize()) {
                         inventory.setItem(slot, icon);
@@ -309,6 +321,27 @@ public class AuctionMenu implements Listener {
             inventory.setItem(ordersToggleSlot, ordersToggle);
         }
 
+        // Show team-listings toggle at slot 50 when team auctions are available;
+        // otherwise fall back to the search tips button
+        boolean teamAvailable = auctionManager.isTeamAuctionsAvailable()
+                && player.hasPermission("ezauction.auction.team");
+        if (teamAvailable && teamListingsToggleConfig != null) {
+            ItemStack teamToggle = createToggleButton(view == BrowserView.TEAM_LISTINGS, teamListingsToggleConfig,
+                    ChatColor.AQUA + "Viewing Team Listings", ChatColor.YELLOW + "Click to browse your team's listings.");
+            setPersistent(teamToggle, actionKey, ACTION_TOGGLE_TEAM_LISTINGS);
+            int teamToggleSlot = teamListingsToggleConfig.slot();
+            if (teamToggleSlot >= 0 && teamToggleSlot < inventory.getSize()) {
+                inventory.setItem(teamToggleSlot, teamToggle);
+            }
+        } else if (searchTipsButtonConfig != null) {
+            ItemStack searchTipsButton = createSearchTipsButton();
+            setPersistent(searchTipsButton, actionKey, ACTION_SEARCH_TIPS);
+            int searchTipsSlot = searchTipsButtonConfig.slot();
+            if (searchTipsSlot >= 0 && searchTipsSlot < inventory.getSize()) {
+                inventory.setItem(searchTipsSlot, searchTipsButton);
+            }
+        }
+
         if (searchButtonConfig != null) {
             ItemStack searchButton = createSearchButton(view, searchQuery);
             setPersistent(searchButton, actionKey, ACTION_SEARCH);
@@ -324,15 +357,6 @@ public class AuctionMenu implements Listener {
             int sortSlot = sortButtonConfig.slot();
             if (sortSlot >= 0 && sortSlot < inventory.getSize()) {
                 inventory.setItem(sortSlot, sortButton);
-            }
-        }
-
-        if (searchTipsButtonConfig != null) {
-            ItemStack searchTipsButton = createSearchTipsButton();
-            setPersistent(searchTipsButton, actionKey, ACTION_SEARCH_TIPS);
-            int searchTipsSlot = searchTipsButtonConfig.slot();
-            if (searchTipsSlot >= 0 && searchTipsSlot < inventory.getSize()) {
-                inventory.setItem(searchTipsSlot, searchTipsButton);
             }
         }
 
@@ -531,6 +555,9 @@ public class AuctionMenu implements Listener {
         appendEstimatedValue(display, lore);
         appendShopPrice(display, lore);
         lore.add(ChatColor.GRAY + "Expires: " + ChatColor.YELLOW + DateUtil.formatDate(listing.expiryEpochMillis()));
+        if (listing.isTeamListing()) {
+            lore.add(ChatColor.AQUA + "[Team Listing]");
+        }
         lore.add(" ");
         if (isShulkerBox(display)) {
             lore.add(colorize(messages.shulkerPreviewHint()));
@@ -587,12 +614,7 @@ public class AuctionMenu implements Listener {
         if (listingId == null || listingId.isEmpty()) {
             return null;
         }
-        for (AuctionListing listing : auctionManager.listActiveListings()) {
-            if (listing.id().equalsIgnoreCase(listingId)) {
-                return listing;
-            }
-        }
-        return null;
+        return auctionManager.findListingById(listingId);
     }
 
     private AuctionOrder findOrder(String orderId) {
@@ -832,6 +854,13 @@ public class AuctionMenu implements Listener {
             runSync(() -> openBrowser(player, BrowserView.ORDERS, 0));
             return;
         }
+        if (ACTION_TOGGLE_TEAM_LISTINGS.equalsIgnoreCase(action)) {
+            if (!auctionManager.isTeamAuctionsAvailable() || !player.hasPermission("ezauction.auction.team")) {
+                return;
+            }
+            runSync(() -> openBrowser(player, BrowserView.TEAM_LISTINGS, 0));
+            return;
+        }
         if (ACTION_SEARCH.equalsIgnoreCase(action)) {
             handleSearchClick(player, holder, event);
             return;
@@ -980,7 +1009,7 @@ public class AuctionMenu implements Listener {
     private void handleSortClick(Player player, BrowserMenuHolder holder, InventoryClickEvent event) {
         UUID playerId = player.getUniqueId();
         boolean backwards = event.isRightClick();
-        if (holder.view() == BrowserView.LISTINGS) {
+        if (holder.view() == BrowserView.LISTINGS || holder.view() == BrowserView.TEAM_LISTINGS) {
             ListingSort current = getListingSort(playerId);
             ListingSort updated = backwards ? current.previous() : current.next();
             activeListingSorts.put(playerId, updated);

--- a/src/main/java/com/skyblockexp/ezauction/gui/AuctionSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/AuctionSellMenu.java
@@ -47,6 +47,7 @@ public class AuctionSellMenu {
     private static final String ACTION_DURATION_NEXT = "duration_next";
     private static final String ACTION_CONFIRM = "confirm";
     private static final String ACTION_CANCEL = "cancel";
+    private static final String ACTION_AMOUNT_ADJUST = "amount_adjust";
 
     private final JavaPlugin plugin;
     private final AuctionManager auctionManager;
@@ -56,6 +57,7 @@ public class AuctionSellMenu {
 
     private final String actionKey;
     private final String priceAdjustKey;
+    private final String amountAdjustKey;
     private final ItemTagStorage itemTagStorage;
 
     private final AuctionMenuInteractionConfiguration.SellMenuLayoutConfiguration layout;
@@ -70,6 +72,7 @@ public class AuctionSellMenu {
     private final Duration longestDurationOption;
     private final double defaultPrice;
     private final double[] priceAdjustments;
+    private final int[] amountAdjustments;
     private final SellMessages messages;
     private LiveAuctionManager liveAuctionManager; 
 
@@ -86,6 +89,7 @@ public class AuctionSellMenu {
         this.messages = messages != null ? messages : SellMessages.defaults();
         this.actionKey = "auction_sell_action";
         this.priceAdjustKey = "auction_sell_adjust";
+        this.amountAdjustKey = "auction_sell_amount";
         this.itemTagStorage = Objects.requireNonNull(itemTagStorage, "itemTagStorage");
         this.pendingPriceInputs = new ConcurrentHashMap<>();
         this.durationOptions = buildDurationOptions(listingRules, configuredDurationOptions);
@@ -104,7 +108,12 @@ public class AuctionSellMenu {
             Double value = adjustments.get(i);
             this.priceAdjustments[i] = value != null ? value.doubleValue() : 0.0D;
         }
-        
+        List<Integer> qtyAdjustments = interactions.quantityAdjustments();
+        this.amountAdjustments = new int[qtyAdjustments.size()];
+        for (int i = 0; i < qtyAdjustments.size(); i++) {
+            Integer value = qtyAdjustments.get(i);
+            this.amountAdjustments[i] = value != null ? value.intValue() : 0;
+        }
         this.liveAuctionManager = null;
     }
 
@@ -193,10 +202,12 @@ public class AuctionSellMenu {
         applyFiller(inventory);
 
         placePriceAdjustmentButtons(inventory);
+        placeAmountAdjustmentButtons(inventory);
 
         ItemStack listingItem = holder.state().item();
         ItemMeta meta = listingItem.getItemMeta();
         List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Amount: " + ChatColor.AQUA + holder.state().quantity());
         lore.add(ChatColor.GRAY + "Listing Price: " + ChatColor.GOLD + formatPrice(holder.state().price()));
         Double recommended = holder.state().recommendedPrice();
         if (recommended != null) {
@@ -217,6 +228,9 @@ public class AuctionSellMenu {
 
         ItemStack priceDisplay = createPriceDisplay(holder);
         inventory.setItem(layout.priceDisplay().slot(), priceDisplay);
+
+        ItemStack quantityDisplay = createQuantityDisplay(holder);
+        inventory.setItem(layout.quantityDisplay().slot(), quantityDisplay);
 
         ItemStack durationDisplay = createDurationDisplay(holder);
         setPersistent(durationDisplay, actionKey, ACTION_DURATION_NEXT);
@@ -244,6 +258,19 @@ public class AuctionSellMenu {
             ItemStack button = createPriceAdjustButton(amount);
             setPersistent(button, actionKey, ACTION_PRICE_ADJUST);
             setPersistent(button, priceAdjustKey, amount);
+            inventory.setItem(slots[i], button);
+        }
+    }
+
+    private void placeAmountAdjustmentButtons(Inventory inventory) {
+        int[] adjustments = amountAdjustments;
+        int[] slots = layout.quantityAdjustmentSlots();
+        for (int i = 0; i < adjustments.length && i < slots.length; i++) {
+            int amount = adjustments[i];
+            if (amount == 0) continue;
+            ItemStack button = createAmountAdjustButton(amount);
+            setPersistent(button, actionKey, ACTION_AMOUNT_ADJUST);
+            setPersistent(button, amountAdjustKey, (double) amount);
             inventory.setItem(slots[i], button);
         }
     }
@@ -350,6 +377,7 @@ public class AuctionSellMenu {
             }
             List<String> lore = new ArrayList<>();
             lore.add(ChatColor.GRAY + "Item: " + ChatColor.AQUA + describeItem(holder.state().item()));
+            lore.add(ChatColor.GRAY + "Amount: " + ChatColor.AQUA + holder.state().quantity());
             lore.add(ChatColor.GRAY + "Price: " + ChatColor.GOLD + formatPrice(holder.state().price()));
             Double recommended = holder.state().recommendedPrice();
             if (recommended != null) {
@@ -392,37 +420,49 @@ public class AuctionSellMenu {
     private ItemStack createPriceAdjustButton(double amount) {
         boolean positive = amount > 0;
         double displayAmount = Math.abs(amount);
-        Material material;
-        if (displayAmount >= 1000.0D) {
-            material = positive ? Material.DIAMOND_BLOCK : Material.REDSTONE_BLOCK;
-        } else if (displayAmount >= 100.0D) {
-            material = positive ? Material.DIAMOND : Material.REDSTONE;
-        } else if (displayAmount >= 10.0D) {
-            material = positive ? Material.EMERALD_BLOCK : Material.REDSTONE_TORCH;
-        } else {
-            material = positive ? Material.EMERALD : Material.COAL;
-        }
+        Material material = positive ? Material.LIME_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE;
         String prefix = positive ? ChatColor.GREEN + "+" : ChatColor.RED + "-";
-        String display = prefix + formatNumber(displayAmount);
-        ItemStack item = material != null ? new ItemStack(material) : null;
-        if (item == null) {
-            item = new ItemStack(Material.STONE);
-        }
+        ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(display + ChatColor.GOLD + " coins");
-            List<String> lore = new ArrayList<>();
-            lore.add(ChatColor.GRAY + "Adjust the price by this amount.");
-            meta.setLore(lore);
+            meta.setDisplayName(prefix + formatPrice(displayAmount));
+            meta.setLore(List.of(ChatColor.GRAY + "Adjust the price by this amount."));
             item.setItemMeta(meta);
         }
         return item;
     }
 
-    private String formatNumber(double amount) {
-        if (amount >= 1000.0D && amount % 1000.0D == 0) return String.format(Locale.ENGLISH, "%.0fk", amount / 1000.0D);
-        if (amount % 1.0D == 0) return String.format(Locale.ENGLISH, "%.0f", amount);
-        return String.format(Locale.ENGLISH, "%.2f", amount);
+    private ItemStack createAmountAdjustButton(int amount) {
+        boolean positive = amount > 0;
+        Material material = positive ? Material.CYAN_STAINED_GLASS_PANE : Material.BLUE_STAINED_GLASS_PANE;
+        String prefix = positive ? ChatColor.AQUA + "+" : ChatColor.DARK_AQUA + "-";
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(prefix + Math.abs(amount));
+            meta.setLore(List.of(ChatColor.GRAY + "Adjust the listing amount by this value."));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private ItemStack createQuantityDisplay(SellMenuHolder holder) {
+        AuctionMenuInteractionConfiguration.ButtonLayoutConfiguration definition = layout.quantityDisplay();
+        ItemStack item = createBaseItem(definition.button());
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            String displayName = definition.button().displayName();
+            if (displayName != null && !displayName.isEmpty()) {
+                meta.setDisplayName(colorize(displayName));
+            }
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GRAY + "Amount: " + ChatColor.AQUA + holder.state().quantity());
+            lore.add(ChatColor.GRAY + "Stack Size: " + ChatColor.AQUA + holder.state().item().getAmount());
+            lore.add(ChatColor.GRAY + "Use the buttons around to adjust.");
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 
     private void applyFiller(Inventory inventory) {
@@ -525,6 +565,7 @@ public class AuctionSellMenu {
 
         switch (action) {
             case ACTION_PRICE_ADJUST -> handlePriceAdjust(player, holder, clicked);
+            case ACTION_AMOUNT_ADJUST -> handleAmountAdjust(holder, clicked);
             case ACTION_PRICE_CUSTOM -> startCustomPriceInput(player, holder);
             case ACTION_DURATION_NEXT -> {
                 holder.state().cycleDuration();
@@ -555,6 +596,13 @@ public class AuctionSellMenu {
        Internal helpers
        ========================= */
 
+    private void handleAmountAdjust(SellMenuHolder holder, ItemStack clicked) {
+        Double raw = itemTagStorage.getDouble(clicked, amountAdjustKey);
+        if (raw == null) return;
+        holder.state().adjustQuantity(raw.intValue());
+        refreshMenu(holder);
+    }
+
     private void handlePriceAdjust(Player player, SellMenuHolder holder, ItemStack clicked) {
         Double amount = itemTagStorage.getDouble(clicked, priceAdjustKey);
         if (amount == null) return;
@@ -576,13 +624,13 @@ public class AuctionSellMenu {
         AuctionOperationResult result;
         if (holder.target() == Target.LIVE && liveAuctionManager != null) {
             // LIVE flow
-            result = liveAuctionManager.createLiveListing(player, state.item(), state.price(), state.duration());
+            result = liveAuctionManager.createLiveListing(player, state.itemWithQuantity(), state.price(), state.duration());
         } else if (holder.target() == Target.TEAM) {
             // Team auction flow
-            result = auctionManager.createTeamListing(player, state.item(), state.price(), state.duration());
+            result = auctionManager.createTeamListing(player, state.itemWithQuantity(), state.price(), state.duration());
         } else {
             // Normal AH flow (fallback)
-            result = auctionManager.createListing(player, state.item(), state.price(), state.duration());
+            result = auctionManager.createListing(player, state.itemWithQuantity(), state.price(), state.duration());
         }
 
         if (result.message() != null && !result.message().isEmpty()) {

--- a/src/main/java/com/skyblockexp/ezauction/gui/AuctionSellMenu.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/AuctionSellMenu.java
@@ -158,6 +158,13 @@ public class AuctionSellMenu {
     }
 
     /**
+     * Opens the sell menu for the team auction target.
+     */
+    public void openTeamSell(Player player) {
+        openSellMenu(player, SellMenuHolder.Target.TEAM);
+    }
+
+    /**
      * Opens the sell menu for the live auction target.
      * Used by the /liveauction sell command.
      */
@@ -570,6 +577,9 @@ public class AuctionSellMenu {
         if (holder.target() == Target.LIVE && liveAuctionManager != null) {
             // LIVE flow
             result = liveAuctionManager.createLiveListing(player, state.item(), state.price(), state.duration());
+        } else if (holder.target() == Target.TEAM) {
+            // Team auction flow
+            result = auctionManager.createTeamListing(player, state.item(), state.price(), state.duration());
         } else {
             // Normal AH flow (fallback)
             result = auctionManager.createListing(player, state.item(), state.price(), state.duration());

--- a/src/main/java/com/skyblockexp/ezauction/gui/BrowserView.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/BrowserView.java
@@ -2,5 +2,6 @@ package com.skyblockexp.ezauction.gui;
 
 public enum BrowserView {
     LISTINGS,
+    TEAM_LISTINGS,
     ORDERS
 }

--- a/src/main/java/com/skyblockexp/ezauction/gui/SellMenuHolder.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/SellMenuHolder.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.Inventory;
 
 public final class SellMenuHolder implements org.bukkit.inventory.InventoryHolder {
 
-    public enum Target { NORMAL, LIVE }
+    public enum Target { NORMAL, LIVE, TEAM }
 
     private final UUID owner;
     private final SellMenuState state;

--- a/src/main/java/com/skyblockexp/ezauction/gui/SellMenuState.java
+++ b/src/main/java/com/skyblockexp/ezauction/gui/SellMenuState.java
@@ -12,6 +12,7 @@ public final class SellMenuState {
     private double price;
     private int durationIndex;
     private final Double recommendedPrice;
+    private int quantity;
 
     private final Duration[] durationOptions;
     private final AuctionListingRules listingRules;
@@ -30,10 +31,18 @@ public final class SellMenuState {
         this.defaultDurationIndex = Math.max(0, defaultDurationIndex);
         this.durationIndex = normalizeIndex(defaultDurationIndex);
         this.recommendedPrice = recommendedPrice;
+        this.quantity = Math.max(1, this.item.getAmount());
     }
 
     public ItemStack item() {
         return item.clone();
+    }
+
+    /** Returns a clone of the item with its amount set to the current {@link #quantity()}. */
+    public ItemStack itemWithQuantity() {
+        ItemStack copy = item.clone();
+        copy.setAmount(quantity);
+        return copy;
     }
 
     public double price() {
@@ -42,6 +51,17 @@ public final class SellMenuState {
 
     public void setPrice(double price) {
         this.price = price;
+    }
+
+    public int quantity() {
+        return quantity;
+    }
+
+    /**
+     * Adjusts the quantity by {@code delta}, clamped to {@code [1, item.getAmount()]}.
+     */
+    public void adjustQuantity(int delta) {
+        quantity = Math.max(1, Math.min(item.getAmount(), quantity + delta));
     }
 
     public Double recommendedPrice() {

--- a/src/main/java/com/skyblockexp/ezauction/integration/TeamsIntegration.java
+++ b/src/main/java/com/skyblockexp/ezauction/integration/TeamsIntegration.java
@@ -1,0 +1,82 @@
+package com.skyblockexp.ezauction.integration;
+
+import com.skyblockexp.teamsapi.api.TeamsAPI;
+import com.skyblockexp.teamsapi.model.Team;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Null-safe facade for the optional TeamsAPI soft-dependency.
+ *
+ * <p>All methods guard against {@code TeamsAPI} being absent on the classpath or not yet
+ * initialised. Any {@link Throwable} thrown by the underlying API is caught and treated as
+ * "not available" so the plugin degrades gracefully.</p>
+ */
+public class TeamsIntegration {
+
+    private final JavaPlugin plugin;
+
+    public TeamsIntegration(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Returns {@code true} if TeamsAPI is present on the classpath and its service is available.
+     */
+    public boolean isAvailable() {
+        try {
+            return TeamsAPI.isAvailable();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the {@link Team} the given player belongs to, or an empty {@link Optional} if the
+     * player has no team or TeamsAPI is unavailable.
+     *
+     * @param playerUUID the player's UUID
+     * @return an {@link Optional} containing the player's team, or empty
+     */
+    public Optional<Team> getPlayerTeam(UUID playerUUID) {
+        if (!isAvailable()) {
+            return Optional.empty();
+        }
+        try {
+            return TeamsAPI.getService().getPlayerTeam(playerUUID);
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns the UUID of the team the given player belongs to, or an empty {@link Optional}.
+     *
+     * @param playerUUID the player's UUID
+     * @return an {@link Optional} containing the team UUID, or empty
+     */
+    public Optional<UUID> getTeamId(UUID playerUUID) {
+        return getPlayerTeam(playerUUID).map(Team::getId);
+    }
+
+    /**
+     * Returns {@code true} if both players are members of the same team.
+     *
+     * @param player1 UUID of the first player
+     * @param player2 UUID of the second player
+     * @return {@code true} if both share a team
+     */
+    public boolean isSameTeam(UUID player1, UUID player2) {
+        if (!isAvailable()) {
+            return false;
+        }
+        try {
+            Optional<Team> team = TeamsAPI.getService().getPlayerTeam(player1);
+            return team.map(t -> t.isMember(player2)).orElse(false);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/skyblockexp/ezauction/live/LiveAuctionManager.java
+++ b/src/main/java/com/skyblockexp/ezauction/live/LiveAuctionManager.java
@@ -121,7 +121,8 @@ public final class LiveAuctionManager {
                 normalizedPrice,
                 expiry,
                 listingItem,
-                normalizedDeposit
+                normalizedDeposit,
+                null
         );
 
         // Enqueue to LIVE (announces / queues depending on config)

--- a/src/main/java/com/skyblockexp/ezauction/service/AuctionListingService.java
+++ b/src/main/java/com/skyblockexp/ezauction/service/AuctionListingService.java
@@ -5,6 +5,7 @@ import com.skyblockexp.ezauction.*;
 import com.skyblockexp.ezauction.event.AuctionListingCreateEvent;
 import com.skyblockexp.ezauction.event.AuctionListingSellEvent;
 import com.skyblockexp.ezauction.event.AuctionListingSoldEvent;
+import com.skyblockexp.ezauction.integration.TeamsIntegration;
 import com.skyblockexp.ezauction.live.LiveAuctionService;
 import com.skyblockexp.ezauction.notification.AuctionNotificationService;
 import com.skyblockexp.ezauction.history.AuctionTransactionHistoryService;
@@ -39,6 +40,7 @@ public class AuctionListingService {
     private final AuctionTransactionHistoryService transactionHistoryService;
     private final Map<UUID, List<ItemStack>> pendingReturns;
     private final Map<String, AuctionOrder> orders; // Needed for persistence
+    private final TeamsIntegration teamsIntegration;
 
     public AuctionListingService(
             AuctionTransactionService transactionService,
@@ -54,6 +56,26 @@ public class AuctionListingService {
             Map<String, AuctionListing> listings,
             Map<String, AuctionOrder> orders
     ) {
+        this(transactionService, listingLimitResolver, configuration, listingRules, liveAuctionService,
+                persistenceManager, notificationService, claimService, transactionHistoryService,
+                pendingReturns, listings, orders, null);
+    }
+
+    public AuctionListingService(
+            AuctionTransactionService transactionService,
+            AuctionListingLimitResolver listingLimitResolver,
+            AuctionConfiguration configuration,
+            AuctionListingRules listingRules,
+            LiveAuctionService liveAuctionService,
+            AuctionPersistenceManager persistenceManager,
+            AuctionNotificationService notificationService,
+            AuctionClaimService claimService,
+            AuctionTransactionHistoryService transactionHistoryService,
+            Map<UUID, List<ItemStack>> pendingReturns,
+            Map<String, AuctionListing> listings,
+            Map<String, AuctionOrder> orders,
+            TeamsIntegration teamsIntegration
+    ) {
         this.listings = listings;
         this.transactionService = transactionService;
         this.listingLimitResolver = listingLimitResolver;
@@ -66,9 +88,20 @@ public class AuctionListingService {
         this.transactionHistoryService = transactionHistoryService;
         this.pendingReturns = pendingReturns;
         this.orders = orders;
+        this.teamsIntegration = teamsIntegration;
     }
 
     public AuctionOperationResult createListing(Player seller, ItemStack item, double price, Duration duration) {
+        return createListing(seller, item, price, duration, null);
+    }
+
+    /**
+     * Creates a new auction listing.
+     *
+     * @param teamId when non-null the listing is restricted to members of this team; pass
+     *               {@code null} for a global listing visible to everyone
+     */
+    public AuctionOperationResult createListing(Player seller, ItemStack item, double price, Duration duration, UUID teamId) {
                 if (configuration.debug()) {
                     System.out.println("[EzAuction][DEBUG] createListing called: seller=" + (seller != null ? seller.getName() : "null") + ", item=" + (item != null ? item.getType() : "null") + ", price=" + price + ", duration=" + duration);
                 }
@@ -77,6 +110,17 @@ public class AuctionListingService {
         }
         if (item == null || item.getType() == Material.AIR || item.getAmount() <= 0) {
             return AuctionOperationResult.failure("You must provide a valid item to list.");
+        }
+
+        // Team scope validation
+        if (teamId != null) {
+            if (teamsIntegration == null || !teamsIntegration.isAvailable()) {
+                return AuctionOperationResult.failure("Team auctions are not available on this server.");
+            }
+            Optional<UUID> sellerTeamId = teamsIntegration.getTeamId(seller.getUniqueId());
+            if (sellerTeamId.isEmpty() || !sellerTeamId.get().equals(teamId)) {
+                return AuctionOperationResult.failure("You are not a member of the specified team.");
+            }
         }
 
         AuctionListingCreateEvent event = new AuctionListingCreateEvent(seller, item, price);
@@ -140,7 +184,7 @@ public class AuctionListingService {
 
         String id = UUID.randomUUID().toString();
         long expiry = System.currentTimeMillis() + sanitizedDuration.toMillis();
-        AuctionListing listing = new AuctionListing(id, seller.getUniqueId(), normalizedPrice, expiry, listingItem, normalizedDeposit);
+        AuctionListing listing = new AuctionListing(id, seller.getUniqueId(), normalizedPrice, expiry, listingItem, normalizedDeposit, teamId);
         listings.put(id, listing);
                 if (configuration.debug()) {
                     System.out.println("[EzAuction][DEBUG] Listing added to map: id=" + id + ", listing=" + listing);
@@ -176,6 +220,16 @@ public class AuctionListingService {
         }
         if (listing.sellerId().equals(buyer.getUniqueId())) {
             return AuctionOperationResult.failure("You cannot purchase your own listing.");
+        }
+
+        // Team scope validation: buyer must be a member of the seller's team
+        if (listing.isTeamListing()) {
+            if (teamsIntegration == null || !teamsIntegration.isAvailable()) {
+                return AuctionOperationResult.failure("Team listings cannot be purchased: TeamsAPI is unavailable.");
+            }
+            if (!teamsIntegration.isSameTeam(listing.sellerId(), buyer.getUniqueId())) {
+                return AuctionOperationResult.failure("You must be a member of the seller's team to purchase this listing.");
+            }
         }
 
         // Fire AuctionListingSellEvent (cancellable) before sale

--- a/src/main/java/com/skyblockexp/ezauction/service/AuctionQueryService.java
+++ b/src/main/java/com/skyblockexp/ezauction/service/AuctionQueryService.java
@@ -1,6 +1,7 @@
 package com.skyblockexp.ezauction.service;
 
 import com.skyblockexp.ezauction.*;
+import com.skyblockexp.ezauction.integration.TeamsIntegration;
 import com.skyblockexp.ezauction.live.LiveAuctionEntry;
 import com.skyblockexp.ezauction.live.LiveAuctionService;
 import com.skyblockexp.ezauction.config.AuctionConfiguration;
@@ -15,21 +16,33 @@ public class AuctionQueryService {
     private final Map<String, AuctionOrder> orders;
     private final LiveAuctionService liveAuctionService;
     private final AuctionConfiguration configuration;
+    private final TeamsIntegration teamsIntegration;
 
     public AuctionQueryService(Map<String, AuctionListing> listings,
                               Map<String, AuctionOrder> orders,
                               LiveAuctionService liveAuctionService,
                               AuctionConfiguration configuration) {
+        this(listings, orders, liveAuctionService, configuration, null);
+    }
+
+    public AuctionQueryService(Map<String, AuctionListing> listings,
+                              Map<String, AuctionOrder> orders,
+                              LiveAuctionService liveAuctionService,
+                              AuctionConfiguration configuration,
+                              TeamsIntegration teamsIntegration) {
         this.listings = listings;
         this.orders = orders;
         this.liveAuctionService = liveAuctionService;
         this.configuration = configuration;
+        this.teamsIntegration = teamsIntegration;
     }
 
     public List<AuctionListing> listActiveListings() {
         List<AuctionListing> active = new ArrayList<>(listings.values());
         long now = System.currentTimeMillis();
         active.removeIf(l -> l.expiryEpochMillis() <= now);
+        // Team-scoped listings are hidden from the global browse view
+        active.removeIf(AuctionListing::isTeamListing);
         active.sort(Comparator.comparingLong(AuctionListing::expiryEpochMillis));
         if (configuration != null && configuration.debug()) {
             System.out.println("[EzAuction][DEBUG] listActiveListings: " + active.size() + " listings: " + active);
@@ -122,5 +135,46 @@ public class AuctionQueryService {
         return orders.values().stream()
                 .filter(order -> order.expiryEpochMillis() > now)
                 .count();
+    }
+
+    /**
+     * Returns active listings scoped to the team of the given viewer, sorted by expiry.
+     * Returns an empty list if the viewer is not in a team or TeamsAPI is unavailable.
+     *
+     * @param viewerId the UUID of the player viewing team listings
+     * @return immutable list of team-scoped active listings visible to this player
+     */
+    public List<AuctionListing> listActiveTeamListings(UUID viewerId) {
+        if (viewerId == null
+                || configuration == null || !configuration.teamAuctionsEnabled()
+                || teamsIntegration == null || !teamsIntegration.isAvailable()) {
+            return Collections.emptyList();
+        }
+        Optional<UUID> teamId = teamsIntegration.getTeamId(viewerId);
+        if (teamId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        UUID tid = teamId.get();
+        long now = System.currentTimeMillis();
+        List<AuctionListing> result = new ArrayList<>();
+        for (AuctionListing l : listings.values()) {
+            if (l.expiryEpochMillis() > now && l.isTeamListing() && tid.equals(l.teamId())) {
+                result.add(l);
+            }
+        }
+        result.sort(Comparator.comparingLong(AuctionListing::expiryEpochMillis));
+        return Collections.unmodifiableList(result);
+    }
+
+    /**
+     * Finds a listing by id regardless of team scope. Used by the GUI confirm flow so
+     * team listings can still be acted upon after the global-filter.
+     *
+     * @param listingId the listing id
+     * @return the {@link AuctionListing}, or {@code null} if not found
+     */
+    public AuctionListing findListingById(String listingId) {
+        if (listingId == null || listingId.isEmpty()) return null;
+        return listings.get(listingId);
     }
 }

--- a/src/main/java/com/skyblockexp/ezauction/storage/mysql/MysqlAuctionListingStorage.java
+++ b/src/main/java/com/skyblockexp/ezauction/storage/mysql/MysqlAuctionListingStorage.java
@@ -71,8 +71,15 @@ public class MysqlAuctionListingStorage implements AuctionStorage, DistributedAu
                     + "price DOUBLE NOT NULL,"
                     + "expiry BIGINT NOT NULL,"
                     + "deposit DOUBLE NOT NULL,"
-                    + "item LONGTEXT NOT NULL"
+                    + "item LONGTEXT NOT NULL,"
+                    + "team_uuid CHAR(36) NULL"
                     + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+            // Migration: add team_uuid column to existing tables that pre-date team auctions
+            try {
+                statement.executeUpdate("ALTER TABLE `" + listingsTable + "` ADD COLUMN team_uuid CHAR(36) NULL");
+            } catch (SQLException ignored) {
+                // Column already exists — safe to ignore
+            }
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS `" + ordersTable + "` ("
                     + "id VARCHAR(36) NOT NULL PRIMARY KEY,"
                     + "buyer_uuid CHAR(36) NOT NULL,"
@@ -108,7 +115,7 @@ public class MysqlAuctionListingStorage implements AuctionStorage, DistributedAu
         if (!isReady()) {
             return AuctionStorageSnapshot.empty();
         }
-        String listingsQuery = "SELECT id, seller_uuid, price, expiry, deposit, item FROM `" + listingsTable + "`";
+        String listingsQuery = "SELECT id, seller_uuid, price, expiry, deposit, item, team_uuid FROM `" + listingsTable + "`";
         try (Connection connection = getConnection();
                 PreparedStatement statement = connection.prepareStatement(listingsQuery);
                 ResultSet resultSet = statement.executeQuery()) {
@@ -129,7 +136,7 @@ public class MysqlAuctionListingStorage implements AuctionStorage, DistributedAu
                 if (item == null || item.getType() == Material.AIR || item.getAmount() <= 0) {
                     continue;
                 }
-                listings.put(id, new AuctionListing(id, sellerId, price, expiry, item, deposit));
+                listings.put(id, new AuctionListing(id, sellerId, price, expiry, item, deposit, parseUuid(resultSet.getString("team_uuid"))));
             }
         } catch (SQLException ex) {
             logger.log(Level.SEVERE,
@@ -238,12 +245,13 @@ public class MysqlAuctionListingStorage implements AuctionStorage, DistributedAu
             return;
         }
         String insert = "INSERT INTO `" + listingsTable
-                + "` (id, seller_uuid, price, expiry, deposit, item) VALUES (?, ?, ?, ?, ?, ?)"
+                + "` (id, seller_uuid, price, expiry, deposit, item, team_uuid) VALUES (?, ?, ?, ?, ?, ?, ?)"
                 + " ON DUPLICATE KEY UPDATE seller_uuid = VALUES(seller_uuid),"
                 + " price = VALUES(price),"
                 + " expiry = VALUES(expiry),"
                 + " deposit = VALUES(deposit),"
-                + " item = VALUES(item)";
+                + " item = VALUES(item),"
+                + " team_uuid = VALUES(team_uuid)";
         try (Connection connection = getConnection();
                 PreparedStatement statement = connection.prepareStatement(insert)) {
             statement.setString(1, listing.id());
@@ -252,6 +260,7 @@ public class MysqlAuctionListingStorage implements AuctionStorage, DistributedAu
             statement.setLong(4, listing.expiryEpochMillis());
             statement.setDouble(5, listing.deposit());
             statement.setString(6, ItemStackSerialization.serialize(listing.item(), logger));
+            statement.setString(7, listing.teamId() != null ? listing.teamId().toString() : null);
             statement.executeUpdate();
         } catch (SQLException ex) {
             logger.log(Level.SEVERE,

--- a/src/main/java/com/skyblockexp/ezauction/storage/yaml/YamlAuctionStorage.java
+++ b/src/main/java/com/skyblockexp/ezauction/storage/yaml/YamlAuctionStorage.java
@@ -141,6 +141,9 @@ public final class YamlAuctionStorage implements AuctionStorage {
             listingSection.set("expiry", listing.expiryEpochMillis());
             listingSection.set("deposit", listing.deposit());
             listingSection.set("item", listing.item());
+            if (listing.teamId() != null) {
+                listingSection.set("team-id", listing.teamId().toString());
+            }
         }
         ConfigurationSection ordersSection = configuration.createSection("orders");
         for (AuctionOrder order : orders) {
@@ -216,7 +219,16 @@ public final class YamlAuctionStorage implements AuctionStorage {
             plugin.getLogger().warning("Ignoring auction listing " + id + " because the item is invalid.");
             return null;
         }
-        return new AuctionListing(id, sellerId, price, expiry, item.clone(), deposit);
+        String teamIdRaw = section.getString("team-id", null);
+        UUID teamId = null;
+        if (teamIdRaw != null && !teamIdRaw.isEmpty()) {
+            try {
+                teamId = UUID.fromString(teamIdRaw);
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning("Ignoring invalid team-id for listing " + id + ": " + teamIdRaw);
+            }
+        }
+        return new AuctionListing(id, sellerId, price, expiry, item.clone(), deposit, teamId);
     }
 
     private AuctionOrder loadOrder(String id, ConfigurationSection section) {

--- a/src/main/resources/auction.yml
+++ b/src/main/resources/auction.yml
@@ -38,3 +38,6 @@ live-auctions:
 
 history-gui:
   enabled: true # Set to false to disable the auction history GUI and related commands.
+
+team-auctions:
+  enabled: true # Set to false to disable team-scoped auction listings.

--- a/src/main/resources/messages/menu-layout_en.yml
+++ b/src/main/resources/messages/menu-layout_en.yml
@@ -53,6 +53,12 @@ browser:
       display-name: "&aBuy Orders"
       lore:
         - "&7Browse active buy orders."
+    team-listings:
+      slot: 50
+      material: SHIELD
+      display-name: "&bTeam Auctions"
+      lore:
+        - "&7Browse your team's listings."
 confirm:
   title: "&2Confirm Purchase"
   size: 27

--- a/src/main/resources/messages/menu-layout_es.yml
+++ b/src/main/resources/messages/menu-layout_es.yml
@@ -29,6 +29,12 @@ browser:
       display-name: "&aÓrdenes de compra"
       lore:
         - "&7Explora las órdenes de compra activas."
+    team-listings:
+      slot: 50
+      material: SHIELD
+      display-name: "&bSubastas de equipo"
+      lore:
+        - "&7Explora las publicaciones de tu equipo."
 confirm:
   title: "&2Confirmar compra"
   size: 27

--- a/src/main/resources/messages/menu-layout_nl.yml
+++ b/src/main/resources/messages/menu-layout_nl.yml
@@ -29,6 +29,12 @@ browser:
       display-name: "&aAankooporders"
       lore:
         - "&7Bekijk actieve aankooporders."
+    team-listings:
+      slot: 50
+      material: SHIELD
+      display-name: "&bTeamveilingen"
+      lore:
+        - "&7Bekijk de aanbiedingen van je team."
 confirm:
   title: "&2Bevestig aankoop"
   size: 27

--- a/src/main/resources/messages/menu-layout_zh.yml
+++ b/src/main/resources/messages/menu-layout_zh.yml
@@ -30,6 +30,12 @@ browser:
       display-name: "&a求购订单"
       lore:
         - "&7浏览进行中的求购订单。"
+    team-listings:
+      slot: 50
+      material: SHIELD
+      display-name: "&b队伍拍卖"
+      lore:
+        - "&7浏览你队伍的拍卖品。"
 confirm:
   title: "&2确认购买"
   size: 27

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -152,3 +152,9 @@ backend:
     buyer-expired: "&eYour buy order for &b{item}&e has expired. Reserved funds were refunded."
   live:
     broadcast: "&6[Live Auction] &a{seller}&7 is auctioning &b{item}&7 for &6{price}&7."
+  team-auctions:
+    no-permission: "&cYou do not have permission to use team auctions."
+    disabled: "&cTeam auctions are not available on this server."
+    not-in-team: "&cYou must be in a team to create a team listing."
+    buyer-not-in-team: "&cYou must be a member of the seller's team to purchase this listing."
+    teams-unavailable: "&cTeam auctions are currently unavailable."

--- a/src/main/resources/messages/messages_es.yml
+++ b/src/main/resources/messages/messages_es.yml
@@ -152,3 +152,9 @@ backend:
     buyer-expired: "&eTu orden de compra de &b{item}&e ha expirado. Los fondos reservados fueron reembolsados."
   live:
     broadcast: "&6[Subasta en Vivo] &a{seller}&7 está subastando &b{item}&7 por &6{price}&7."
+  team-auctions:
+    no-permission: "&cNo tienes permiso para usar las subastas de equipo."
+    disabled: "&cLas subastas de equipo no están disponibles en este servidor."
+    not-in-team: "&cDebes estar en un equipo para crear una publicación de equipo."
+    buyer-not-in-team: "&cDebes ser miembro del equipo del vendedor para comprar esta publicación."
+    teams-unavailable: "&cLas subastas de equipo no están disponibles actualmente."

--- a/src/main/resources/messages/messages_nl.yml
+++ b/src/main/resources/messages/messages_nl.yml
@@ -152,3 +152,9 @@ backend:
     buyer-expired: "&eJe kooporder voor &b{item}&e is verlopen. Gereserveerde fondsen zijn terugbetaald."
   live:
     broadcast: "&6[Live Veiling] &a{seller}&7 veilt &b{item}&7 voor &6{price}&7."
+  team-auctions:
+    no-permission: "&cJe hebt geen toestemming om teamveilingen te gebruiken."
+    disabled: "&cTeamveilingen zijn niet beschikbaar op deze server."
+    not-in-team: "&cJe moet in een team zitten om een teamvermelding aan te maken."
+    buyer-not-in-team: "&cJe moet lid zijn van het team van de verkoper om dit item te kopen."
+    teams-unavailable: "&cTeamveilingen zijn momenteel niet beschikbaar."

--- a/src/main/resources/messages/messages_zh.yml
+++ b/src/main/resources/messages/messages_zh.yml
@@ -151,4 +151,9 @@ backend:
     buyer-delivery-failed: "&e无法交付订单物品。请检查你的背包。"
     buyer-expired: "&e你的求购订单 &b{item}&e 已过期。预留的资金已退还。"
   live:
-    broadcast: "&6[现场拍卖] &a{seller}&7 正在拍卖 &b{item}&7，当前价格 &6{price}&7。"
+    broadcast: "&6[现场拍卖] &a{seller}&7 正在拍卖 &b{item}&7，当前价格 &6{price}&7。"  team-auctions:
+    no-permission: "&c您没有权限使用队伍拍卖。"
+    disabled: "&c本服务器未启用队伍拍卖。"
+    not-in-team: "&c您必须加入队伍才能创建队伍拍卖。"
+    buyer-not-in-team: "&c您必须是卖家队伍的成员才能购买此拍品。"
+    teams-unavailable: "&c队伍拍卖目前不可用。"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 main: com.skyblockexp.ezauction.EzAuctionPlugin
 author: Shadow48402
 description: Standalone auction house plugin for EzAuction-powered Minecraft servers (requires Vault + economy provider).
-softdepend: [Vault, EzShops, SkyblockExperienceCommon, EzScoreboard, PlaceholderAPI, DiscordSRV]
+softdepend: [Vault, EzShops, SkyblockExperienceCommon, EzScoreboard, PlaceholderAPI, DiscordSRV, TeamsAPI]
 api-version: 1.13
 commands:
   auction:
@@ -78,6 +78,12 @@ permissions:
     default: op
   ezauction.auction.live:
     description: Allows players to view the live auction queue.
+    default: true
+  ezauction.auction.team:
+    description: Allows players to browse team-scoped auction listings.
+    default: true
+  ezauction.auction.team.sell:
+    description: Allows players to create team-scoped auction listings.
     default: true
   ezauction.hologram:
     description: Allows administrators to place and remove EzAuction holograms.

--- a/src/test/java/com/skyblockexp/ezauction/AuctionManagerTest.java
+++ b/src/test/java/com/skyblockexp/ezauction/AuctionManagerTest.java
@@ -94,7 +94,7 @@ class AuctionManagerTest {
         UUID buyerId = UUID.randomUUID();
         ItemStack item = new ItemStack(Material.DIAMOND, 1);
         AuctionListing listing = new AuctionListing("listing-1", sellerId, 100.0D,
-                System.currentTimeMillis() + Duration.ofMinutes(5).toMillis(), item, 10.0D);
+                System.currentTimeMillis() + Duration.ofMinutes(5).toMillis(), item, 10.0D, null);
 
         Player buyer = mock(Player.class);
         PlayerInventory buyerInventory = mock(PlayerInventory.class);
@@ -125,7 +125,7 @@ class AuctionManagerTest {
         UUID sellerId = UUID.randomUUID();
         ItemStack item = new ItemStack(Material.DIAMOND, 1);
         AuctionListing listing = new AuctionListing("listing-2", sellerId, 75.0D,
-                System.currentTimeMillis() + Duration.ofMinutes(5).toMillis(), item, 5.0D);
+                System.currentTimeMillis() + Duration.ofMinutes(5).toMillis(), item, 5.0D, null);
 
         when(transactionService.formatCurrency(anyDouble())).thenAnswer(invocation -> {
             double amount = invocation.getArgument(0);
@@ -155,7 +155,7 @@ class AuctionManagerTest {
         UUID sellerId = UUID.randomUUID();
         ItemStack item = new ItemStack(Material.DIAMOND, 1);
         AuctionListing listing = new AuctionListing("listing-3", sellerId, 50.0D,
-                System.currentTimeMillis() - Duration.ofMinutes(1).toMillis(), item, 4.0D);
+                System.currentTimeMillis() - Duration.ofMinutes(1).toMillis(), item, 4.0D, null);
 
         when(transactionService.formatCurrency(anyDouble())).thenAnswer(invocation -> {
             double amount = invocation.getArgument(0);

--- a/src/test/java/com/skyblockexp/ezauction/TeamAuctionListingServiceTest.java
+++ b/src/test/java/com/skyblockexp/ezauction/TeamAuctionListingServiceTest.java
@@ -1,0 +1,185 @@
+package com.skyblockexp.ezauction;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.skyblockexp.ezauction.config.AuctionConfiguration;
+import com.skyblockexp.ezauction.integration.TeamsIntegration;
+import com.skyblockexp.ezauction.service.AuctionQueryService;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TeamAuctionListingServiceTest {
+
+    private TeamsIntegration teamsIntegration;
+
+    @BeforeEach
+    void setUp() {
+        teamsIntegration = mock(TeamsIntegration.class);
+    }
+
+    private AuctionQueryService buildQueryService(Map<String, AuctionListing> listings) {
+        AuctionConfiguration configuration = AuctionManagerTestUtils.mockAuctionConfiguration();
+        when(configuration.teamAuctionsEnabled()).thenReturn(true);
+        return new AuctionQueryService(listings, new HashMap<>(), null, configuration, teamsIntegration);
+    }
+
+    private AuctionQueryService buildQueryServiceTeamDisabled(Map<String, AuctionListing> listings) {
+        AuctionConfiguration configuration = AuctionManagerTestUtils.mockAuctionConfiguration();
+        when(configuration.teamAuctionsEnabled()).thenReturn(false);
+        return new AuctionQueryService(listings, new HashMap<>(), null, configuration, teamsIntegration);
+    }
+
+    @Test
+    void listActiveListingsFiltersOutTeamListings() {
+        UUID sellerId = UUID.randomUUID();
+        UUID teamId = UUID.randomUUID();
+        long expiry = System.currentTimeMillis() + Duration.ofHours(1).toMillis();
+        ItemStack item = new ItemStack(Material.DIAMOND, 1);
+
+        AuctionListing globalListing = new AuctionListing("global-1", sellerId, 50.0D, expiry, item, 0.0D, null);
+        AuctionListing teamListing = new AuctionListing("team-1", sellerId, 75.0D, expiry, item, 0.0D, teamId);
+
+        Map<String, AuctionListing> listings = new HashMap<>();
+        listings.put(globalListing.id(), globalListing);
+        listings.put(teamListing.id(), teamListing);
+
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        AuctionQueryService qs = buildQueryService(listings);
+
+        List<AuctionListing> active = qs.listActiveListings();
+
+        assertTrue(active.stream().anyMatch(l -> l.id().equals("global-1")),
+                "Global listing should be visible in the global view");
+        assertFalse(active.stream().anyMatch(l -> l.id().equals("team-1")),
+                "Team listing should be filtered out of the global view");
+    }
+
+    @Test
+    void listActiveTeamListingsReturnsOnlyMatchingTeam() {
+        UUID sellerId = UUID.randomUUID();
+        UUID viewerId = UUID.randomUUID();
+        UUID teamId = UUID.randomUUID();
+        UUID otherTeamId = UUID.randomUUID();
+        long expiry = System.currentTimeMillis() + Duration.ofHours(1).toMillis();
+        ItemStack item = new ItemStack(Material.DIAMOND, 1);
+
+        AuctionListing ownTeamListing = new AuctionListing("team-own", sellerId, 50.0D, expiry, item, 0.0D, teamId);
+        AuctionListing otherTeamListing = new AuctionListing("team-other", sellerId, 75.0D, expiry, item, 0.0D, otherTeamId);
+        AuctionListing globalListing = new AuctionListing("global-1", sellerId, 10.0D, expiry, item, 0.0D, null);
+
+        Map<String, AuctionListing> listings = new HashMap<>();
+        listings.put(ownTeamListing.id(), ownTeamListing);
+        listings.put(otherTeamListing.id(), otherTeamListing);
+        listings.put(globalListing.id(), globalListing);
+
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        when(teamsIntegration.getTeamId(viewerId)).thenReturn(Optional.of(teamId));
+
+        AuctionQueryService qs = buildQueryService(listings);
+        List<AuctionListing> teamActive = qs.listActiveTeamListings(viewerId);
+
+        assertTrue(teamActive.stream().anyMatch(l -> l.id().equals("team-own")),
+                "Own-team listing should appear in team view");
+        assertFalse(teamActive.stream().anyMatch(l -> l.id().equals("team-other")),
+                "Other-team listing should not appear in team view");
+        assertFalse(teamActive.stream().anyMatch(l -> l.id().equals("global-1")),
+                "Global listing should not appear in team view");
+    }
+
+    @Test
+    void listActiveTeamListingsReturnsEmptyWhenTeamsUnavailable() {
+        UUID viewerId = UUID.randomUUID();
+        when(teamsIntegration.isAvailable()).thenReturn(false);
+        AuctionQueryService qs = buildQueryService(new HashMap<>());
+        List<AuctionListing> result = qs.listActiveTeamListings(viewerId);
+        assertTrue(result.isEmpty(), "Should return empty list when TeamsAPI is unavailable");
+    }
+
+    @Test
+    void listActiveTeamListingsReturnsEmptyWhenTeamAuctionsDisabledInConfig() {
+        UUID viewerId = UUID.randomUUID();
+        UUID teamId = UUID.randomUUID();
+        long expiry = System.currentTimeMillis() + Duration.ofHours(1).toMillis();
+        ItemStack item = new ItemStack(Material.DIAMOND, 1);
+        AuctionListing teamListing = new AuctionListing("team-cfg", UUID.randomUUID(), 50.0D, expiry, item, 0.0D, teamId);
+        Map<String, AuctionListing> listings = new HashMap<>();
+        listings.put(teamListing.id(), teamListing);
+
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        when(teamsIntegration.getTeamId(viewerId)).thenReturn(Optional.of(teamId));
+        AuctionQueryService qs = buildQueryServiceTeamDisabled(listings);
+
+        List<AuctionListing> result = qs.listActiveTeamListings(viewerId);
+        assertTrue(result.isEmpty(), "Should return empty list when team-auctions.enabled=false in config");
+    }
+
+    @Test
+    void listActiveTeamListingsReturnsEmptyWhenViewerNotInTeam() {
+        UUID viewerId = UUID.randomUUID();
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        when(teamsIntegration.getTeamId(viewerId)).thenReturn(Optional.empty());
+        AuctionQueryService qs = buildQueryService(new HashMap<>());
+        List<AuctionListing> result = qs.listActiveTeamListings(viewerId);
+        assertTrue(result.isEmpty(), "Should return empty list when viewer is not in a team");
+    }
+
+    @Test
+    void findListingByIdSearchesAllListings() {
+        UUID sellerId = UUID.randomUUID();
+        UUID teamId = UUID.randomUUID();
+        long expiry = System.currentTimeMillis() + Duration.ofHours(1).toMillis();
+        ItemStack item = new ItemStack(Material.DIAMOND, 1);
+
+        AuctionListing teamListing = new AuctionListing("team-find", sellerId, 50.0D, expiry, item, 0.0D, teamId);
+        Map<String, AuctionListing> listings = new HashMap<>();
+        listings.put(teamListing.id(), teamListing);
+
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        AuctionQueryService qs = buildQueryService(listings);
+
+        AuctionListing found = qs.findListingById("team-find");
+        assertNotNull(found, "findListingById should return team listing regardless of scope");
+    }
+
+    @Test
+    void findListingByIdReturnsNullForUnknownId() {
+        when(teamsIntegration.isAvailable()).thenReturn(true);
+        AuctionQueryService qs = buildQueryService(new HashMap<>());
+        assertNull(qs.findListingById("nonexistent"));
+    }
+
+    @Test
+    void auctionListingIsTeamListingReturnsTrueForTeamListing() {
+        UUID teamId = UUID.randomUUID();
+        AuctionListing teamListing = new AuctionListing("t", UUID.randomUUID(), 1.0D,
+                System.currentTimeMillis() + 60_000L, new ItemStack(Material.STONE), 0.0D, teamId);
+        assertTrue(teamListing.isTeamListing());
+    }
+
+    @Test
+    void auctionListingIsTeamListingReturnsFalseForGlobalListing() {
+        AuctionListing globalListing = new AuctionListing("g", UUID.randomUUID(), 1.0D,
+                System.currentTimeMillis() + 60_000L, new ItemStack(Material.STONE), 0.0D, null);
+        assertFalse(globalListing.isTeamListing());
+    }
+
+    @Test
+    void auctionListingGlobalFactoryProducesNullTeamId() {
+        AuctionListing listing = AuctionListing.global("g", UUID.randomUUID(), 1.0D,
+                System.currentTimeMillis() + 60_000L, new ItemStack(Material.STONE), 0.0D);
+        assertFalse(listing.isTeamListing());
+    }
+}

--- a/src/test/java/com/skyblockexp/ezauction/gui/AuctionMenuSortTest.java
+++ b/src/test/java/com/skyblockexp/ezauction/gui/AuctionMenuSortTest.java
@@ -66,7 +66,7 @@ class AuctionMenuSortTest {
     private AuctionListing createListing(String id, Material material, int amount, double price, long minutesUntilExpiry) {
         ItemStack stack = new ItemStack(material, amount);
         long expiry = System.currentTimeMillis() + Duration.ofMinutes(minutesUntilExpiry).toMillis();
-        return new AuctionListing(id, UUID.randomUUID(), price, expiry, stack, 0.0D);
+        return new AuctionListing(id, UUID.randomUUID(), price, expiry, stack, 0.0D, null);
     }
 
     private AuctionOrder createOrder(String id, Material material, int amount, double offeredPrice, long minutesUntilExpiry) {

--- a/src/test/java/com/skyblockexp/ezauction/gui/AuctionSellMenuHelpersTest.java
+++ b/src/test/java/com/skyblockexp/ezauction/gui/AuctionSellMenuHelpersTest.java
@@ -48,18 +48,6 @@ class AuctionSellMenuHelpersTest {
     }
 
     @Test
-    void formatNumberFormatsKilobytesAndDecimals() throws Exception {
-        AuctionSellMenu menu = createMenu();
-
-        Method m = AuctionSellMenu.class.getDeclaredMethod("formatNumber", double.class);
-        m.setAccessible(true);
-
-        assertEquals("1k", m.invoke(menu, 1000.0D));
-        assertEquals("1500", m.invoke(menu, 1500.0D));
-        assertEquals("10.50", m.invoke(menu, 10.5D));
-    }
-
-    @Test
     void formatDurationPrintsDaysHoursMinutes() throws Exception {
         AuctionSellMenu menu = createMenu();
         Method m = AuctionSellMenu.class.getDeclaredMethod("formatDuration", java.time.Duration.class);

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
![Team Auctions](https://i.ibb.co/vCYzR3R6/image.png)

- **Team Auctions**: team-scoped listings visible and purchasable only by members of the seller's team.
  - New command: `/auction team` — browse team listings (hidden when disabled or TeamsAPI absent).
  - New command: `/auction team sell` — list held item as a team auction.
  - `team-auctions.enabled` toggle in `auction.yml` (default `false`).
  - `TeamsIntegration` facade — null-safe soft-dependency wrapper around [TeamsAPI 1.4.0](https://github.com/ez-plugins/teams-api).
  - `AuctionListing.teamId` field persisted to both YAML and MySQL backends.
  - `AuctionListingService` team scope and `AuctionQueryService` team query, both guarded by the config flag.
  - `AuctionManager.createTeamListing()` and `listActiveTeamListings()`.
  - Team browse tab in the auction browser GUI; tab button hidden when team auctions are disabled or TeamsAPI is not installed.
  - `TeamsAPI` added to `softdepend` in `plugin.yml`.
  - Full message keys added across all four language files (`en`, `es`, `nl`, `zh`).
  - New permissions: `ezauction.auction.team`, `ezauction.auction.team.sell`.